### PR TITLE
feat: WASM ビルド識別表示 + wasm-opt ダウンロード失敗の回避

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,3 +36,8 @@ optional = true
 [profile.release]
 opt-level = "s"
 lto = true
+
+# wasm-pack が binaryen v117 を GitHub から自動ダウンロードするが失敗することがあるため無効化。
+# opt-level="s" + lto=true で十分な最適化が効いているのでサイズ増は限定的
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/heads");
+
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=MFC_BUILD_GIT_SHA={sha}");
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    println!("cargo:rustc-env=MFC_BUILD_UNIX_TS={ts}");
+}

--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -2,10 +2,24 @@
 use wasm_bindgen::prelude::*;
 use crate::pipeline;
 
+/// ビルド時に build.rs から埋め込まれる識別子
+pub const BUILD_GIT_SHA: &str = env!("MFC_BUILD_GIT_SHA");
+pub const BUILD_UNIX_TS: &str = env!("MFC_BUILD_UNIX_TS");
+
 /// WASM初期化（パニックフック設定）
 #[wasm_bindgen(start)]
 pub fn init() {
     console_error_panic_hook::set_once();
+}
+
+/// ビルド識別情報を JSON 文字列で返す
+/// JS 側: `{"sha":"abc1234","unixTs":"1713340000"}`
+#[wasm_bindgen]
+pub fn build_info() -> String {
+    format!(
+        "{{\"sha\":\"{}\",\"unixTs\":\"{}\"}}",
+        BUILD_GIT_SHA, BUILD_UNIX_TS
+    )
 }
 
 /// 画像バイト列を受け取り、処理結果をJSONで返す

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tsParser from '@typescript-eslint/parser';
 import globals from 'globals';
 
 export default [
-  { ignores: ['dist/**', 'node_modules/**'] },
+  { ignores: ['dist/**', 'node_modules/**', 'src/wasm/**'] },
   js.configs.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,28 @@
+import { createSignal, onMount, Show } from 'solid-js';
 import type { Page } from '../App';
+import { initWasm, getWasmBuildInfo } from '../lib/wasm/loader';
 
 interface Props {
   onNavigate: (page: Page) => void;
 }
 
 export default function Footer(props: Props) {
+  const [buildLabel, setBuildLabel] = createSignal<string | null>(null);
+
+  onMount(async () => {
+    try {
+      await initWasm();
+      const info = getWasmBuildInfo();
+      if (info) {
+        const dt = new Date(Number(info.unixTs) * 1000);
+        const ymd = dt.toISOString().slice(0, 10);
+        setBuildLabel(`build ${info.sha} (${ymd})`);
+      }
+    } catch {
+      // WASM ロード失敗時は表示しない
+    }
+  });
+
   return (
     <footer class="footer">
       <div class="footer__inner">
@@ -22,6 +40,12 @@ export default function Footer(props: Props) {
         </button>
         <span class="footer__sep">|</span>
         <span class="footer__copy">&copy; kako-jun</span>
+        <Show when={buildLabel()}>
+          <span class="footer__sep">|</span>
+          <span class="footer__build" title="WASM ビルド識別">
+            {buildLabel()}
+          </span>
+        </Show>
       </div>
       <p class="footer__sub">
         全処理がブラウザ内で完結。画像がサーバーに送られることはありません。

--- a/src/lib/scanner/processor.ts
+++ b/src/lib/scanner/processor.ts
@@ -1,5 +1,5 @@
 import JSZip from 'jszip';
-import { processImageWasm, cellToImageData, cellToDataUrl } from '../wasm/loader';
+import { processImageWasm, cellToImageData, cellToDataUrl, getWasmBuildInfo } from '../wasm/loader';
 import type { WasmProcessedCell } from '../wasm/loader';
 import { getCharactersForPage } from '../../data/characters';
 import type { VectorGlyph } from '../font/builder';
@@ -51,15 +51,24 @@ function correctedImageToCanvas(
 
 /**
  * WASMからのエラーメッセージをユーザーフレンドリーな日本語に変換する
+ * エラー末尾にビルド識別情報（sha）を付加し、報告時に版の特定を容易にする
  */
 export function translateWasmError(rawError: string): string {
+  let msg: string;
   // マーカー検出失敗
   if (rawError.includes('マーカーが検出できませんでした')) {
-    return '用紙のマーカーを検出できませんでした。紙全体が写るよう、なるべく正面から撮影してください。';
+    msg =
+      '用紙のマーカーを検出できませんでした。紙全体が写るよう、なるべく正面から撮影してください。';
+  } else {
+    // DPI不足: Rust側のメッセージにDPI値と推奨値が含まれているのでそのまま通す
+    // その他のRustエラーもそのまま返す
+    msg = rawError;
   }
-  // DPI不足: Rust側のメッセージにDPI値と推奨値が含まれているのでそのまま通す
-  // その他のRustエラーもそのまま返す
-  return rawError;
+  const info = getWasmBuildInfo();
+  if (info) {
+    msg += ` [build: ${info.sha}]`;
+  }
+  return msg;
 }
 
 // メイン処理

--- a/src/lib/wasm/loader.ts
+++ b/src/lib/wasm/loader.ts
@@ -10,6 +10,20 @@
 interface MfcWasm {
   default: (input?: string | URL | ArrayBuffer) => Promise<void>;
   process_image: (image_bytes: Uint8Array) => unknown;
+  build_info: () => string;
+}
+
+/** Rust 側 build_info() の JSON 形式 */
+export interface WasmBuildInfo {
+  sha: string;
+  unixTs: string;
+}
+
+let buildInfo: WasmBuildInfo | null = null;
+
+/** 初期化済みの WASM のビルド識別情報を返す（未初期化なら null） */
+export function getWasmBuildInfo(): WasmBuildInfo | null {
+  return buildInfo;
 }
 
 /** Rust側の ProcessedCell に対応 */
@@ -54,6 +68,13 @@ export async function initWasm(): Promise<void> {
     const mod = (await import('../../wasm/mfc.js')) as unknown as MfcWasm;
     await mod.default();
     wasmModule = mod;
+    try {
+      buildInfo = JSON.parse(mod.build_info()) as WasmBuildInfo;
+      const ts = new Date(Number(buildInfo.unixTs) * 1000).toISOString();
+      console.info(`[mfc] WASM build sha=${buildInfo.sha} built=${ts}`);
+    } catch (e) {
+      console.warn('[mfc] build_info() の取得に失敗:', e);
+    }
   })();
 
   await initPromise;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -412,6 +412,12 @@ body {
   opacity: 0.8;
 }
 
+.footer__build {
+  opacity: 0.6;
+  font-family: ui-monospace, 'SF Mono', 'Menlo', monospace;
+  font-size: 0.85em;
+}
+
 .footer__sub {
   font-size: 0.75rem;
   margin-top: 0.25rem;


### PR DESCRIPTION
## 背景

#74 を入れた後の WASM 更新前カイゼンとして、以下2点を実施:

1. **WASM バージョン識別の埋め込み** — デプロイされている WASM がどの時点のビルドかを特定できるように
2. **wasm-opt ダウンロード失敗の回避** — `wasm-pack` が GitHub から binaryen v117 を自動取得して失敗する問題の根絶

## 変更

### wasm-opt 無効化
- `cli/Cargo.toml` に `[package.metadata.wasm-pack.profile.release] wasm-opt = false` を追加
- `opt-level='s'` + `lto=true` が既に効いているためサイズ増は限定的
- ローカル・Cloudflare Pages 両方で動作する

### ビルド識別情報
- `cli/build.rs` 新規: git short SHA と UNIX タイムスタンプを cargo:rustc-env 経由で埋め込み
- `cli/src/wasm.rs`: `build_info()` を wasm-bindgen で公開（`{"sha":"xxx","unixTs":"yyy"}` を返す）
- `src/lib/wasm/loader.ts`: 初期化時にコンソールへ出力 + `getWasmBuildInfo()` を公開
- `src/components/Footer.tsx`: フッター右端に `build <sha> (YYYY-MM-DD)` を表示
- `src/lib/scanner/processor.ts`: エラーメッセージ末尾に `[build: sha]` を付与

### その他
- `eslint.config.js`: 自動生成される `src/wasm/**` を lint 対象から除外（既存のノイズ解消）

## 効果

- デプロイ後、F12 コンソールを開くだけで `[mfc] WASM build sha=xxx built=ISO8601` が確認できる
- フッターからも目視可能
- エラー時のメッセージに SHA が付くため、ユーザー報告の版特定が一発で済む

## Test plan

- [x] `cargo build`（cli）
- [x] `wasm-pack build --target web` 成功確認（binaryen ダウンロード試行なし）
- [x] `vite build` 成功確認
- [x] `npm test` (vitest): 27 passed
- [x] `npm run check`（eslint + prettier）: clean
- [ ] 実デプロイ後に Footer と console.info の表示を確認
- [ ] `IMG_20260416_193821.jpg` を読み込ませて #74 の新ルールで採用されることを確認