### PR TITLE
fix: #77 追従 — WASM ビルド識別の堅牢化（CF Pages対応・Footer軽量化）

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@
 
 モダンブラウザ（Chrome, Firefox, Safari, Edge）
 
+## 不具合の報告
+
+うまく動かない場合は、ページ最下部のフッターに表示されている `build xxxxxxx (YYYY-MM-DD)` を添えて報告してください。エラー発生時のトーストメッセージにも `[build: xxxxxxx]` が付きます。どの版での問題かが特定でき、調査がスムーズになります。
+
 ## 作者
 
 kako-jun — [llll-ll.com](https://llll-ll.com)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 ## 不具合の報告
 
-うまく動かない場合は、ページ最下部のフッターに表示されている `build xxxxxxx (YYYY-MM-DD)` を添えて報告してください。エラー発生時のトーストメッセージにも `[build: xxxxxxx]` が付きます。どの版での問題かが特定でき、調査がスムーズになります。
+うまく動かない場合は [GitHub Issues](https://github.com/kako-jun/my-font-craft/issues) から報告してください。ページ最下部のフッターに表示されている `build xxxxxxx (YYYY-MM-DD)` を添えていただけると版が特定でき、調査がスムーズになります。エラー発生時のトーストメッセージにも `[build: xxxxxxx]` が付きます。
 
 ## 作者
 

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -3,19 +3,32 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    // HEAD 自体とコミットログの更新で再実行（packed-refs 環境でも .git/logs/HEAD は更新される）
     println!("cargo:rerun-if-changed=../.git/HEAD");
-    println!("cargo:rerun-if-changed=../.git/refs/heads");
+    println!("cargo:rerun-if-changed=../.git/logs/HEAD");
+    // CF Pages 等のビルド環境変数を監視
+    println!("cargo:rerun-if-env-changed=CF_PAGES_COMMIT_SHA");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    println!("cargo:rerun-if-env-changed=MFC_BUILD_GIT_SHA_OVERRIDE");
 
-    let sha = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
+    // 優先順位: 明示的オーバーライド → CF Pages → GitHub Actions → git rev-parse → "unknown"
+    let sha = std::env::var("MFC_BUILD_GIT_SHA_OVERRIDE")
         .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-            } else {
-                None
-            }
+        .or_else(|| std::env::var("CF_PAGES_COMMIT_SHA").ok())
+        .or_else(|| std::env::var("GITHUB_SHA").ok())
+        .map(|s| s.chars().take(7).collect::<String>())
+        .or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+                .ok()
+                .and_then(|o| {
+                    if o.status.success() {
+                        Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+                    } else {
+                        None
+                    }
+                })
         })
         .unwrap_or_else(|| "unknown".to_string());
     println!("cargo:rustc-env=MFC_BUILD_GIT_SHA={sha}");

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -11,20 +11,28 @@ fn main() {
     println!("cargo:rerun-if-env-changed=GITHUB_SHA");
     println!("cargo:rerun-if-env-changed=MFC_BUILD_GIT_SHA_OVERRIDE");
 
+    // 環境変数を空文字列フィルタ付きで取得するヘルパ
+    // CI では未設定変数が空文字列としてエクスポートされることがあるため
+    let env_nonempty = |k: &str| std::env::var(k).ok().filter(|s| !s.is_empty());
+
     // 優先順位: 明示的オーバーライド → CF Pages → GitHub Actions → git rev-parse → "unknown"
-    let sha = std::env::var("MFC_BUILD_GIT_SHA_OVERRIDE")
-        .ok()
-        .or_else(|| std::env::var("CF_PAGES_COMMIT_SHA").ok())
-        .or_else(|| std::env::var("GITHUB_SHA").ok())
+    let sha = env_nonempty("MFC_BUILD_GIT_SHA_OVERRIDE")
+        .or_else(|| env_nonempty("CF_PAGES_COMMIT_SHA"))
+        .or_else(|| env_nonempty("GITHUB_SHA"))
         .map(|s| s.chars().take(7).collect::<String>())
         .or_else(|| {
             Command::new("git")
-                .args(["rev-parse", "--short", "HEAD"])
+                .args(["rev-parse", "--short=7", "HEAD"])
                 .output()
                 .ok()
                 .and_then(|o| {
                     if o.status.success() {
-                        Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+                        let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                        if s.is_empty() {
+                            None
+                        } else {
+                            Some(s)
+                        }
                     } else {
                         None
                     }

--- a/cli/src/wasm.rs
+++ b/cli/src/wasm.rs
@@ -13,13 +13,14 @@ pub fn init() {
 }
 
 /// ビルド識別情報を JSON 文字列で返す
-/// JS 側: `{"sha":"abc1234","unixTs":"1713340000"}`
+/// JS 側: `{"sha":"abc1234","unixTs":"1713340000"}`（unixTs は秒単位の文字列）
 #[wasm_bindgen]
 pub fn build_info() -> String {
-    format!(
-        "{{\"sha\":\"{}\",\"unixTs\":\"{}\"}}",
-        BUILD_GIT_SHA, BUILD_UNIX_TS
-    )
+    serde_json::json!({
+        "sha": BUILD_GIT_SHA,
+        "unixTs": BUILD_UNIX_TS,
+    })
+    .to_string()
 }
 
 /// 画像バイト列を受け取り、処理結果をJSONで返す

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,27 +1,19 @@
-import { createSignal, onMount, Show } from 'solid-js';
+import { Show } from 'solid-js';
 import type { Page } from '../App';
-import { initWasm, getWasmBuildInfo } from '../lib/wasm/loader';
+import { wasmBuildInfo } from '../lib/wasm/loader';
 
 interface Props {
   onNavigate: (page: Page) => void;
 }
 
 export default function Footer(props: Props) {
-  const [buildLabel, setBuildLabel] = createSignal<string | null>(null);
-
-  onMount(async () => {
-    try {
-      await initWasm();
-      const info = getWasmBuildInfo();
-      if (info) {
-        const dt = new Date(Number(info.unixTs) * 1000);
-        const ymd = dt.toISOString().slice(0, 10);
-        setBuildLabel(`build ${info.sha} (${ymd})`);
-      }
-    } catch {
-      // WASM ロード失敗時は表示しない
-    }
-  });
+  // WASM はロードしない。他所で initWasm() が走ったらシグナルが立ち自動的に表示される
+  const buildLabel = () => {
+    const info = wasmBuildInfo();
+    if (!info) return null;
+    const ymd = new Date(Number(info.unixTs) * 1000).toISOString().slice(0, 10);
+    return `build ${info.sha} (${ymd})`;
+  };
 
   return (
     <footer class="footer">

--- a/src/lib/scanner/processor.ts
+++ b/src/lib/scanner/processor.ts
@@ -114,7 +114,7 @@ export async function processImages(
     } catch (e) {
       const msg = translateWasmError(
         e instanceof Error ? e.message : String(e),
-        getWasmBuildInfo()?.sha ?? null,
+        getWasmBuildInfo()?.sha,
       );
       callbacks.onMessage({
         type: 'error',

--- a/src/lib/scanner/processor.ts
+++ b/src/lib/scanner/processor.ts
@@ -50,10 +50,11 @@ function correctedImageToCanvas(
 }
 
 /**
- * WASMからのエラーメッセージをユーザーフレンドリーな日本語に変換する
- * エラー末尾にビルド識別情報（sha）を付加し、報告時に版の特定を容易にする
+ * WASMからのエラーメッセージをユーザーフレンドリーな日本語に変換する。
+ * `buildSha` が渡された場合はエラー末尾に `[build: sha]` を付加し、報告時に版特定を容易にする。
+ * 省略時は純粋な変換のみ行う（テスト容易性のため副作用なし）。
  */
-export function translateWasmError(rawError: string): string {
+export function translateWasmError(rawError: string, buildSha?: string | null): string {
   let msg: string;
   // マーカー検出失敗
   if (rawError.includes('マーカーが検出できませんでした')) {
@@ -64,9 +65,8 @@ export function translateWasmError(rawError: string): string {
     // その他のRustエラーもそのまま返す
     msg = rawError;
   }
-  const info = getWasmBuildInfo();
-  if (info) {
-    msg += ` [build: ${info.sha}]`;
+  if (buildSha) {
+    msg += ` [build: ${buildSha}]`;
   }
   return msg;
 }
@@ -112,7 +112,10 @@ export async function processImages(
     try {
       wasmResult = await processImageWasm(imageFiles[fi]);
     } catch (e) {
-      const msg = translateWasmError(e instanceof Error ? e.message : String(e));
+      const msg = translateWasmError(
+        e instanceof Error ? e.message : String(e),
+        getWasmBuildInfo()?.sha ?? null,
+      );
       callbacks.onMessage({
         type: 'error',
         text: `ファイル "${imageFiles[fi].name}" の処理に失敗しました: ${msg}`,

--- a/src/lib/wasm/loader.ts
+++ b/src/lib/wasm/loader.ts
@@ -5,6 +5,8 @@
  * シングルトンで管理し、複数回呼ばれても初期化は1回だけ。
  */
 
+import { createSignal } from 'solid-js';
+
 // wasm-pack が生成するモジュールの型定義
 // 実際のファイルは cli/ で wasm-pack build 後に src/wasm/ に生成される
 interface MfcWasm {
@@ -13,17 +15,21 @@ interface MfcWasm {
   build_info: () => string;
 }
 
-/** Rust 側 build_info() の JSON 形式 */
+/** Rust 側 build_info() の JSON 形式（unixTs は秒単位の文字列） */
 export interface WasmBuildInfo {
   sha: string;
   unixTs: string;
 }
 
-let buildInfo: WasmBuildInfo | null = null;
+/**
+ * ビルド識別情報の Solid シグナル。
+ * `initWasm()` が成功すると値がセットされる。subscribe するだけでは WASM ロードをトリガーしない。
+ */
+export const [wasmBuildInfo, setWasmBuildInfo] = createSignal<WasmBuildInfo | null>(null);
 
-/** 初期化済みの WASM のビルド識別情報を返す（未初期化なら null） */
+/** 現在のビルド識別情報のスナップショットを返す（未初期化なら null） */
 export function getWasmBuildInfo(): WasmBuildInfo | null {
-  return buildInfo;
+  return wasmBuildInfo();
 }
 
 /** Rust側の ProcessedCell に対応 */
@@ -69,9 +75,10 @@ export async function initWasm(): Promise<void> {
     await mod.default();
     wasmModule = mod;
     try {
-      buildInfo = JSON.parse(mod.build_info()) as WasmBuildInfo;
-      const ts = new Date(Number(buildInfo.unixTs) * 1000).toISOString();
-      console.info(`[mfc] WASM build sha=${buildInfo.sha} built=${ts}`);
+      const info = JSON.parse(mod.build_info()) as WasmBuildInfo;
+      setWasmBuildInfo(info);
+      const ts = new Date(Number(info.unixTs) * 1000).toISOString();
+      console.info(`[mfc] WASM build sha=${info.sha} built=${ts}`);
     } catch (e) {
       console.warn('[mfc] build_info() の取得に失敗:', e);
     }

--- a/src/lib/wasm/loader.ts
+++ b/src/lib/wasm/loader.ts
@@ -22,8 +22,12 @@ export interface WasmBuildInfo {
 }
 
 /**
- * ビルド識別情報の Solid シグナル。
- * `initWasm()` が成功すると値がセットされる。subscribe するだけでは WASM ロードをトリガーしない。
+ * ビルド識別情報の Solid シグナル（意図的にモジュール初期化時の「グローバル」配置）。
+ *
+ * Footer 等が購読するだけで WASM ロードをトリガーしないようにするため、
+ * コンポーネント内の `createSignal` ではなくモジュールスコープで作っている。
+ * `initWasm()` が成功したタイミングで `setWasmBuildInfo()` される。
+ * owner 外の createSignal だが、グローバルシグナルの一般的パターンで Solid 上も問題なく動作する。
  */
 export const [wasmBuildInfo, setWasmBuildInfo] = createSignal<WasmBuildInfo | null>(null);
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -414,7 +414,8 @@ body {
 
 .footer__build {
   opacity: 0.6;
-  font-family: ui-monospace, 'SF Mono', 'Menlo', monospace;
+  font-family:
+    ui-monospace, 'SF Mono', 'Menlo', 'Cascadia Code', 'Consolas', 'Liberation Mono', monospace;
   font-size: 0.85em;
 }
 

--- a/tests/unit/processor.test.ts
+++ b/tests/unit/processor.test.ts
@@ -27,4 +27,16 @@ describe('translateWasmError', () => {
     const result = translateWasmError(raw);
     expect(result).toBe(raw);
   });
+
+  it('buildSha が与えられた場合は末尾に [build: sha] を付加する', () => {
+    const raw = '画像デコードエラー: unsupported format';
+    const result = translateWasmError(raw, 'abc1234');
+    expect(result).toBe(`${raw} [build: abc1234]`);
+  });
+
+  it('buildSha が null の場合は build タグを付加しない', () => {
+    const raw = '画像デコードエラー: unsupported format';
+    const result = translateWasmError(raw, null);
+    expect(result).toBe(raw);
+  });
 });


### PR DESCRIPTION
## 背景

PR #77 の遡及セルフレビューで見つかった must 級指摘3件を修正する。

## 修正内容

### 1. build.rs — CF Pages 等の env 優先 + packed-refs 対応

**問題:** `git rev-parse` は shallow clone や `.git` 不完全環境（CF Pages ビルド等）で失敗し、sha が `"unknown"` になる。また `.git/refs/heads` は packed-refs 環境では更新されずに rerun-if-changed が効かない。

**対策:**

- env 優先順位: `MFC_BUILD_GIT_SHA_OVERRIDE` → `CF_PAGES_COMMIT_SHA` → `GITHUB_SHA` → `git rev-parse --short HEAD` → `"unknown"`
- `rerun-if-changed` を `.git/logs/HEAD`（packed-refs でも更新される）に変更
- 上記 env の変更検出も追加

### 2. Footer — WASM の eager ロード排除

**問題:** PR #77 の Footer は全ページで `initWasm()` を即実行していたため、撮影しないユーザーにまで 1.9MB の WASM DL を強制していた。

**対策:**

- `src/lib/wasm/loader.ts` で Solid の `createSignal` による `wasmBuildInfo` を公開
- Footer はシグナルを subscribe するだけ。`initWasm()` は呼ばない
- Upload 等で実際に WASM が初期化されたら、自動的にフッターに表示される

### 3. translateWasmError — テスト決定論化

**問題:** `translateWasmError()` がモジュールスコープの `getWasmBuildInfo()` を直接呼んでおり、テスト時「たまたま null だから pass」という脆い状態だった。

**対策:**

- `translateWasmError(raw: string, buildSha?: string | null)` に変更
- 呼び出し側（processor.ts メイン処理）で明示的に `getWasmBuildInfo()?.sha` を渡す
- テストを追加（buildSha 有/無 の 2 ケース）

## Test plan

- [x] `cargo build`（cli）: OK
- [x] `wasm-pack build --target web`: OK
- [x] `vite build`: OK
- [x] `npm test`: 29 passed（+2）
- [x] `npm run check`: clean
- [ ] CF Pages デプロイ後に sha が `unknown` ではなく実 SHA になることを確認
- [ ] Upload ページ遷移前はフッターに build 表示がないこと、Upload で WASM ロード後に表示されることを確認