### PR TITLE
fix: #80 QR パーサを JSON v2 形式に対応

### DIFF
--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -322,7 +322,12 @@ pub fn process_image_bytes(bytes: &[u8]) -> Result<ProcessResult, String> {
     let (page_number, total_pages) = match read_qr_from_corrected_wasm(&corrected) {
         Ok(data) => {
             log!("  QRデータ: {data}");
-            parse_qr_page_info(&data)
+            let parsed = parse_qr_page_info(&data);
+            if parsed == (None, None) {
+                let preview: String = data.chars().take(80).collect();
+                log!("  ⚠ QRデータをパースできませんでした（page_numberなし）: {preview}");
+            }
+            parsed
         }
         Err(e) => {
             log!("  QR読み取り失敗（続行）: {e}");
@@ -400,8 +405,8 @@ fn parse_qr_page_info(data: &str) -> (Option<u32>, Option<u32>) {
     // v2: JSON 形式
     if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
         if v.get("p").and_then(|x| x.as_str()) == Some("mfc") {
-            let page = v.get("pg").and_then(|x| x.as_u64()).map(|n| n as u32);
-            let total = v.get("t").and_then(|x| x.as_u64()).map(|n| n as u32);
+            let page = v.get("pg").and_then(|x| x.as_u64()).and_then(|n| u32::try_from(n).ok());
+            let total = v.get("t").and_then(|x| x.as_u64()).and_then(|n| u32::try_from(n).ok());
             return (page, total);
         }
     }
@@ -456,6 +461,22 @@ mod qr_parse_tests {
         let (p, t) = parse_qr_page_info(r#"{"p":"mfc"}"#);
         assert_eq!(p, None);
         assert_eq!(t, None);
+    }
+
+    #[test]
+    fn v2_json_missing_p_key() {
+        // p キー自体が無い場合（将来 TS 側がキー名を変えた時の回帰検知）
+        let (p, t) = parse_qr_page_info(r#"{"product":"mfc","pg":1,"t":2}"#);
+        assert_eq!(p, None);
+        assert_eq!(t, None);
+    }
+
+    #[test]
+    fn v2_json_overflow_u32() {
+        // u32::MAX 超の値は try_from で弾かれて None になる
+        let (p, t) = parse_qr_page_info(r#"{"p":"mfc","pg":4294967296,"t":2}"#);
+        assert_eq!(p, None);
+        assert_eq!(t, Some(2));
     }
 
     #[test]

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -391,9 +391,23 @@ pub fn process_image_bytes(bytes: &[u8]) -> Result<ProcessResult, String> {
 }
 
 /// QRデータからページ情報を抽出
+///
+/// 優先形式（v2, 現行）: JSON `{"p":"mfc","v":2,"pg":N,"t":M,"m":2}`
+/// 後方互換（v1）: プレーンテキスト `mfc:N/M`
 fn parse_qr_page_info(data: &str) -> (Option<u32>, Option<u32>) {
-    // QRデータ形式: "mfc:1/3" など（ページ番号/全ページ数）
-    if let Some(stripped) = data.strip_prefix("mfc:") {
+    let trimmed = data.trim();
+
+    // v2: JSON 形式
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if v.get("p").and_then(|x| x.as_str()) == Some("mfc") {
+            let page = v.get("pg").and_then(|x| x.as_u64()).map(|n| n as u32);
+            let total = v.get("t").and_then(|x| x.as_u64()).map(|n| n as u32);
+            return (page, total);
+        }
+    }
+
+    // v1: プレーンテキスト "mfc:N/M"
+    if let Some(stripped) = trimmed.strip_prefix("mfc:") {
         let parts: Vec<&str> = stripped.split('/').collect();
         if parts.len() == 2 {
             let page = parts[0].parse().ok();
@@ -401,7 +415,76 @@ fn parse_qr_page_info(data: &str) -> (Option<u32>, Option<u32>) {
             return (page, total);
         }
     }
+
     (None, None)
+}
+
+#[cfg(test)]
+mod qr_parse_tests {
+    use super::parse_qr_page_info;
+
+    #[test]
+    fn v2_json_basic() {
+        let (p, t) = parse_qr_page_info(r#"{"p":"mfc","v":2,"pg":1,"t":2,"m":2}"#);
+        assert_eq!(p, Some(1));
+        assert_eq!(t, Some(2));
+    }
+
+    #[test]
+    fn v2_json_with_extra_fields() {
+        let (p, t) = parse_qr_page_info(r#"{"p":"mfc","v":2,"pg":3,"t":10,"m":2,"chars":["あ","い"]}"#);
+        assert_eq!(p, Some(3));
+        assert_eq!(t, Some(10));
+    }
+
+    #[test]
+    fn v2_json_with_whitespace() {
+        let (p, t) = parse_qr_page_info("  {\"p\":\"mfc\",\"pg\":5,\"t\":7}  ");
+        assert_eq!(p, Some(5));
+        assert_eq!(t, Some(7));
+    }
+
+    #[test]
+    fn v2_json_wrong_product_rejected() {
+        let (p, t) = parse_qr_page_info(r#"{"p":"other","pg":1,"t":2}"#);
+        assert_eq!(p, None);
+        assert_eq!(t, None);
+    }
+
+    #[test]
+    fn v2_json_missing_fields() {
+        let (p, t) = parse_qr_page_info(r#"{"p":"mfc"}"#);
+        assert_eq!(p, None);
+        assert_eq!(t, None);
+    }
+
+    #[test]
+    fn v1_plain_text_basic() {
+        let (p, t) = parse_qr_page_info("mfc:1/3");
+        assert_eq!(p, Some(1));
+        assert_eq!(t, Some(3));
+    }
+
+    #[test]
+    fn v1_plain_text_with_whitespace() {
+        let (p, t) = parse_qr_page_info(" mfc:2/5 ");
+        assert_eq!(p, Some(2));
+        assert_eq!(t, Some(5));
+    }
+
+    #[test]
+    fn invalid_returns_none() {
+        let (p, t) = parse_qr_page_info("garbage");
+        assert_eq!(p, None);
+        assert_eq!(t, None);
+    }
+
+    #[test]
+    fn empty_string_returns_none() {
+        let (p, t) = parse_qr_page_info("");
+        assert_eq!(p, None);
+        assert_eq!(t, None);
+    }
 }
 
 // ── 共通処理関数（CLI/WASM両方で使用） ──


### PR DESCRIPTION
## 関連 Issue

closes #80

## 背景（致命的バグ）

Web UI で正面撮影画像をアップロードしてもフォント生成が 0/0 で必ず失敗する。

F12 コンソールの Rust ログでは:
- QR は正常に読み取れている: `QRデータ: {"p":"mfc","v":2,"pg":1,"t":2,"m":2}`
- セル抽出も成功: `文字サマリー: 採用=8, 空=39, 合計=47`

しかし JS 側 `processor.ts` が `wasmResult.page_number` を null として受け取り、「QRコードを読み取れませんでした」エラーで全てのセルを破棄してしまう。

## 原因

`cli/src/pipeline.rs::parse_qr_page_info()` が旧プレーンテキスト形式 `mfc:N/M` のみを想定していた。

一方、現行の QR 生成側（`src/lib/template/generator.ts:180-191`、`cli/generate-test-pdf.ts:120`）はいずれも JSON v2 形式 `{"p":"mfc","v":2,"pg":N,"t":M,"m":2}` で生成している。形式変更時にパーサー更新が漏れたと推測。

## 修正

```rust
fn parse_qr_page_info(data: &str) -> (Option<u32>, Option<u32>) {
    let trimmed = data.trim();

    // v2: JSON 形式
    if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
        if v.get("p").and_then(|x| x.as_str()) == Some("mfc") {
            let page = v.get("pg").and_then(|x| x.as_u64()).map(|n| n as u32);
            let total = v.get("t").and_then(|x| x.as_u64()).map(|n| n as u32);
            return (page, total);
        }
    }

    // v1: プレーンテキスト（後方互換）
    if let Some(stripped) = trimmed.strip_prefix("mfc:") {
        // ...
    }

    (None, None)
}
```

- `serde_json` は既に依存に含まれている（他所で使用中）のでサイズ増なし
- v1 形式も後方互換として残存させ、旧テンプレートを印刷済みのユーザーに配慮
- 前後空白を `trim()` で許容

## テスト追加（9ケース）

- v2 JSON: 基本 / 追加フィールド (`chars`) / 前後空白 / product 不一致 / フィールド欠損
- v1 プレーンテキスト: 基本 / 前後空白
- 不正 JSON（"garbage"）/ 空文字列

## Test plan

- [x] `cargo test --lib`: 51 passed（+9）
- [x] `wasm-pack build --target web`: OK
- [x] `vite build`: OK
- [x] `npm test`: 29 passed
- [ ] マージ後の CF Pages デプロイで `IMG_20260416_193821.jpg` を再度アップロードし、8 文字が抽出されてフォント生成が完了することを確認

## 関連

この修正が入ると、既にマージ済みの #74 (×廃止・6ルール採用判定) が初めて Web UI で実動作する。