### PR TITLE
fix: #82 セル画像切り出しを grid_removed ベースに修正

### DIFF
--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -358,13 +358,12 @@ pub fn process_image_bytes(bytes: &[u8]) -> Result<ProcessResult, String> {
     // 結果をProcessResult に変換
     let corrected_width = grid_removed.width();
     let corrected_height = grid_removed.height();
-    let corrected_image = grid_removed.into_raw();
 
     let mut cells = Vec::new();
     for cr in &char_results {
         let char_index = layout::grid_to_char_index(cr.row, cr.col);
         for slot in &cr.slots {
-            let cell_img = cell::extract_cell_image(&shadow_corrected, cr.row, cr.col, slot.cell_index);
+            let cell_img = cell::extract_cell_image(&grid_removed, cr.row, cr.col, slot.cell_index);
             let width = cell_img.width();
             let height = cell_img.height();
             let image_data = cell_img.into_raw();
@@ -384,6 +383,8 @@ pub fn process_image_bytes(bytes: &[u8]) -> Result<ProcessResult, String> {
             });
         }
     }
+
+    let corrected_image = grid_removed.into_raw();
 
     Ok(ProcessResult {
         page_number,


### PR DESCRIPTION
## 関連 Issue
closes #82

## 変更内容

`cli/src/pipeline.rs` のWASMパイプラインで、UI/ベクター化に渡すセル画像を `shadow_corrected`（シアン・罫線が残った中間段階）から切り出していたバグを修正。`grid_removed`（最終段階）に統一する。

解析（`cell::extract_and_judge_in_memory`）は既に `grid_removed` を使っており、セル切り出しだけ取り残されていた。

### 症状と原因
- **結果グリッドが灰色背景＋シアン四角**: `shadow_corrected` はまだシアン除去前
- **「フォントを作成」で無反応**: `src/lib/vectorizer/contour.ts` の大津二値化でシアン（グレー換算≈238）が「黒」として拾われ、巨大輪郭の処理が実質ハング

### 構造変更
`grid_removed.into_raw()` の呼び出しをセル切り出しループの後に移動（ループ内で `&grid_removed` を借りるため、消費タイミングを後ろにずらした）。

## 動作確認
- [x] `cargo check` / `cargo test --lib` (53 passed)
- [x] `wasm-pack build --target web --out-dir ../src/wasm --release`
- [ ] ブラウザで実機確認（セル画像が白背景＋黒文字、フォント生成が完走）