### PR TITLE
スキャン結果グリッドのセル間隔を詰めて密接表示に

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -777,7 +777,7 @@ body {
 .scan-grid__chars {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
-  gap: 2px;
+  gap: 0;
 }
 
 .scan-grid__cell {


### PR DESCRIPTION
## 変更内容

`src/styles/global.css` の `.scan-grid__chars` の `gap: 2px` を `0` に。
各セルは `border: 1px` を保持しているので、境界線は引き続き見える。セル同士が詰まることで、1ページ47文字の一覧性が上がり「格子」として視認しやすくなる。

## 背景

セッション242 の実機スキャンで UI を見た際の UX 指摘:
> 読み取り結果表示で格子状に並ぶ文字の矩形の間隔はいらず、密接していて良い

## テスト
- Vite build 成功