### PR TITLE
feat: マージ仕様を後勝ちに変更 + scanner 内重複排除 (#93)

### DIFF
--- a/docs/font-generation.md
+++ b/docs/font-generation.md
@@ -170,8 +170,8 @@ opentype.js の `parse()` で取得したグリフのパスコマンドを内部
 
 由来は `GlyphStatus.status` フィールドで識別する（新規メタフィールドは追加しない）:
 
-- **画像（スキャン）→ 何でも**: 後勝ち。新しい `found` は既存の `found` / `imported` / `empty` を全て上書きする。同 unicode の旧 alt-variant も合わせて破棄する
-- **TTF インポート → 既存**: 既存非上書き。`empty` のみを `imported` で穴埋めし、画像由来 (`found`) には触れない
+- **画像（スキャン）→ 何でも**: 後勝ち。新しい `found` は既存の `found` / `imported` / `empty` を全て上書きする。同 unicode の旧 alt-variant も合わせて破棄し、新スキャン側の alt-variant は採用する
+- **TTF インポート → 既存**: 画像由来 (`found`) は守る。`empty` / 既存 `imported` は新しい `imported` で置き換える（TTF同士は後勝ち）
 - **scanner 内部の重複排除**: 同一アップロード内で同じ unicode が複数回検出された場合（複数ページに同じ字、複数画像が同じ字を含む等）、ベースグリフは Map で後勝ち、alt は対応する旧 alt を破棄してから追加する
 
 ---

--- a/docs/font-generation.md
+++ b/docs/font-generation.md
@@ -166,8 +166,13 @@ opentype.js の `parse()` で取得したグリフのパスコマンドを内部
 | `imported` | 既存TTF  | 中                 |
 | `empty`    | 未検出   | 低                 |
 
-- スキャン → TTF インポート: `empty` を `imported` で穴埋め
-- TTF インポート → スキャン: `imported` を `found` で上書き
+#### マージ仕様（Issue #93）
+
+由来は `GlyphStatus.status` フィールドで識別する（新規メタフィールドは追加しない）:
+
+- **画像（スキャン）→ 何でも**: 後勝ち。新しい `found` は既存の `found` / `imported` / `empty` を全て上書きする。同 unicode の旧 alt-variant も合わせて破棄する
+- **TTF インポート → 既存**: 既存非上書き。`empty` のみを `imported` で穴埋めし、画像由来 (`found`) には触れない
+- **scanner 内部の重複排除**: 同一アップロード内で同じ unicode が複数回検出された場合（複数ページに同じ字、複数画像が同じ字を含む等）、ベースグリフは Map で後勝ち、alt は対応する旧 alt を破棄してから追加する
 
 ---
 

--- a/src/lib/merge.ts
+++ b/src/lib/merge.ts
@@ -3,7 +3,8 @@ import type { VectorGlyph } from './font/builder';
 
 /**
  * スキャン結果を既存のステータス/グリフにマージする
- * found が imported / empty を上書き（スキャンが優先）
+ * 画像由来 (found) は後勝ち: 新しいスキャンは既存の found / imported / empty を全て上書きする
+ * （Issue #93: マージ仕様 — 画像は後勝ち / TTFは既存非上書き）
  */
 export function mergeScanIntoExisting(
   prevStatuses: GlyphStatus[],
@@ -17,7 +18,8 @@ export function mergeScanIntoExisting(
   }
 
   const statuses = prevStatuses.map((gs) => {
-    if ((gs.status === 'empty' || gs.status === 'imported') && newFound.has(gs.unicode)) {
+    // 画像由来は後勝ち: 既存の status を問わず新しい found で上書きする
+    if (newFound.has(gs.unicode)) {
       return newFound.get(gs.unicode)!;
     }
     return gs;

--- a/src/lib/merge.ts
+++ b/src/lib/merge.ts
@@ -33,8 +33,14 @@ export function mergeScanIntoExisting(
     return isNaN(baseUnicode) || !newFoundUnicodes.has(baseUnicode);
   });
 
-  const existingKeptUnicodes = new Set(keptGlyphs.map((g) => g.unicode));
-  const addedGlyphs = newGlyphs.filter((g) => g.unicode && !existingKeptUnicodes.has(g.unicode));
+  // 新しい glyph はベースも alt-variant も全て採用する。
+  // newFound に含まれる unicode に紐づくものだけ通せば、processor が
+  // 「同じ unicode のベース + alt 群」を一塊で吐き出す前提で安全。
+  const addedGlyphs = newGlyphs.filter((g) => {
+    if (g.unicode) return newFoundUnicodes.has(g.unicode);
+    const baseUnicode = parseInt(g.name.replace(/^uni/, '').replace(/\.alt\d+$/, ''), 16);
+    return !isNaN(baseUnicode) && newFoundUnicodes.has(baseUnicode);
+  });
   const glyphs = [...keptGlyphs, ...addedGlyphs];
 
   return { statuses, glyphs };
@@ -42,7 +48,9 @@ export function mergeScanIntoExisting(
 
 /**
  * インポート結果を既存のステータス/グリフにマージする
- * empty のみを imported で埋める（found は上書きしない）
+ * - empty / imported を新しい imported で置き換える（TTF同士は後勝ち）
+ * - found（画像由来）は守る（TTFは画像由来を上書きしない）
+ * （Issue #93: マージ仕様）
  */
 export function mergeImportIntoExisting(
   prevStatuses: GlyphStatus[],
@@ -58,16 +66,34 @@ export function mergeImportIntoExisting(
     });
   }
 
+  // 画像由来 (found) の unicode を保護する
+  const protectedUnicodes = new Set<number>();
+  for (const gs of prevStatuses) {
+    if (gs.status === 'found') protectedUnicodes.add(gs.unicode);
+  }
+
   const statuses = prevStatuses.map((gs) => {
-    if (gs.status === 'empty' && importedMap.has(gs.unicode)) {
+    // found は守る、empty / imported は新しい imported で置き換える（後勝ち）
+    if (gs.status !== 'found' && importedMap.has(gs.unicode)) {
       return importedMap.get(gs.unicode)!.status;
     }
     return gs;
   });
 
-  const existingUnicodes = new Set(prevGlyphs.map((g) => g.unicode));
-  const addedGlyphs = importedGlyphs.filter((g) => g.unicode && !existingUnicodes.has(g.unicode));
-  const glyphs = [...prevGlyphs, ...addedGlyphs];
+  // 既存 glyphs から、画像非保護かつ imported に同 unicode が来ているものを除外
+  // （これにより TTF→TTF が後勝ちで置換される）
+  const keptGlyphs = prevGlyphs.filter((g) => {
+    if (!g.unicode) return true; // alt-variant は判定保留（importFont は alt を作らないため実質発生しない）
+    if (protectedUnicodes.has(g.unicode)) return true;
+    return !importedMap.has(g.unicode);
+  });
+
+  const keptUnicodes = new Set(keptGlyphs.map((g) => g.unicode));
+  // 画像由来で守られている unicode は新規 import からも弾く
+  const addedGlyphs = importedGlyphs.filter(
+    (g) => g.unicode && !protectedUnicodes.has(g.unicode) && !keptUnicodes.has(g.unicode),
+  );
+  const glyphs = [...keptGlyphs, ...addedGlyphs];
 
   return { statuses, glyphs };
 }

--- a/src/lib/scanner/processor.ts
+++ b/src/lib/scanner/processor.ts
@@ -80,7 +80,10 @@ export async function processImages(
   files: File[],
   callbacks: ProcessCallbacks,
 ): Promise<ProcessResult> {
-  const glyphs: VectorGlyph[] = [];
+  // Issue #93: 同一 unicode が複数ページ／複数画像で検出されたときの重複を防ぐため、
+  // ベースグリフは Map で後勝ち上書き、alt-variant は別配列に積んで関数末尾で結合する。
+  const baseGlyphs = new Map<number, VectorGlyph>();
+  const altGlyphs: VectorGlyph[] = [];
 
   // ZIP展開 + 画像ファイル収集
   let imageFiles: File[] = [];
@@ -104,7 +107,7 @@ export async function processImages(
 
   if (imageFiles.length === 0) {
     callbacks.onMessage({ type: 'error', text: '画像ファイルが見つかりませんでした。' });
-    return { glyphs };
+    return { glyphs: [] };
   }
 
   callbacks.onPageStart(0, imageFiles.length);
@@ -217,6 +220,16 @@ export async function processImages(
         cellImageDataUrl,
       });
 
+      // 既に同 unicode のベースグリフが登録済みなら、対応する旧 alt-variant を破棄
+      // （後勝ちで上書きされるベースに紐づく古い alt が残らないようにする）
+      if (baseGlyphs.has(unicode)) {
+        const hex = unicode.toString(16).toUpperCase().padStart(4, '0');
+        const altPrefix = `uni${hex}.alt`;
+        for (let i = altGlyphs.length - 1; i >= 0; i--) {
+          if (altGlyphs[i].name.startsWith(altPrefix)) altGlyphs.splice(i, 1);
+        }
+      }
+
       for (let ai = 0; ai < adoptedCells.length; ai++) {
         const cell = adoptedCells[ai];
         // ベクター化は Rust 側で完結済み。WASM 出力の paths をそのまま使う
@@ -227,15 +240,22 @@ export async function processImages(
             ? `uni${unicode.toString(16).toUpperCase().padStart(4, '0')}`
             : `uni${unicode.toString(16).toUpperCase().padStart(4, '0')}.alt${ai}`;
 
-        glyphs.push({
+        const glyph: VectorGlyph = {
           name,
           unicode: ai === 0 ? unicode : undefined,
           paths,
           advanceWidth: 1000,
-        });
+        };
+
+        if (ai === 0) {
+          // ベースグリフは後勝ち
+          baseGlyphs.set(unicode, glyph);
+        } else {
+          altGlyphs.push(glyph);
+        }
       }
     }
   }
 
-  return { glyphs };
+  return { glyphs: [...baseGlyphs.values(), ...altGlyphs] };
 }

--- a/tests/unit/merge.test.ts
+++ b/tests/unit/merge.test.ts
@@ -101,6 +101,28 @@ describe('mergeScanIntoExisting', () => {
     expect(result.glyphs[0].name).toBe('uni3042');
     expect(result.glyphs.find((g) => g.name.includes('.alt'))).toBeUndefined();
   });
+
+  it('新スキャンの alt-variant も後勝ちで採用される (Issue #93 / レビューM2)', () => {
+    // 既存: ベースのみ
+    const prev = makeGlyph('あ');
+    prev.advanceWidth = 800;
+    const prevStatuses = [makeStatus('あ', 'found')];
+    const prevGlyphs = [prev];
+    // 新スキャン: ベース + alt1 + alt2
+    const newBase = makeGlyph('あ');
+    newBase.advanceWidth = 1500;
+    const newAlt1 = makeGlyph('あ', 1);
+    const newAlt2 = makeGlyph('あ', 2);
+    const newStatuses = [makeStatus('あ', 'found')];
+    const newGlyphs = [newBase, newAlt1, newAlt2];
+
+    const result = mergeScanIntoExisting(prevStatuses, prevGlyphs, newStatuses, newGlyphs);
+
+    // ベース置換 + alt 2件追加 = 計3件
+    expect(result.glyphs).toHaveLength(3);
+    expect(result.glyphs[0].advanceWidth).toBe(1500);
+    expect(result.glyphs.filter((g) => g.name.includes('.alt'))).toHaveLength(2);
+  });
 });
 
 describe('mergeImportIntoExisting', () => {
@@ -154,5 +176,29 @@ describe('mergeImportIntoExisting', () => {
 
     expect(result.statuses).toHaveLength(1);
     expect(result.glyphs).toHaveLength(1);
+  });
+
+  it('imported は新しい imported で後勝ち上書きされる (Issue #93 / レビューM1)', () => {
+    const prev = makeGlyph('あ');
+    prev.advanceWidth = 700;
+    const prevStatuses = [makeStatus('あ', 'imported')];
+    const prevGlyphs = [prev];
+
+    const next = makeGlyph('あ');
+    next.advanceWidth = 1300;
+    const importedStatuses = [makeStatus('あ', 'imported')];
+    importedStatuses[0].pageIndex = 5;
+    const importedGlyphs = [next];
+
+    const result = mergeImportIntoExisting(
+      prevStatuses,
+      prevGlyphs,
+      importedStatuses,
+      importedGlyphs,
+    );
+
+    expect(result.statuses[0].pageIndex).toBe(5);
+    expect(result.glyphs).toHaveLength(1);
+    expect(result.glyphs[0].advanceWidth).toBe(1300);
   });
 });

--- a/tests/unit/merge.test.ts
+++ b/tests/unit/merge.test.ts
@@ -51,22 +51,47 @@ describe('mergeScanIntoExisting', () => {
     expect(result.glyphs).toHaveLength(1);
   });
 
-  it('found は既存の found を上書きしない', () => {
+  it('found は既存の found を後勝ちで上書きする (Issue #93)', () => {
     const prevStatuses = [makeStatus('あ', 'found')];
-    const prevGlyphs = [makeGlyph('あ')];
-    const newStatuses = [makeStatus('あ', 'found')];
-    const newGlyphs = [makeGlyph('あ')];
+    const prevGlyph = makeGlyph('あ');
+    prevGlyph.advanceWidth = 800; // 旧
+    const prevGlyphs = [prevGlyph];
+
+    const newStatusObj = makeStatus('あ', 'found');
+    newStatusObj.pageIndex = 7; // 識別用に値を変える
+    const newGlyph = makeGlyph('あ');
+    newGlyph.advanceWidth = 1200; // 新
+    const newStatuses = [newStatusObj];
+    const newGlyphs = [newGlyph];
 
     const result = mergeScanIntoExisting(prevStatuses, prevGlyphs, newStatuses, newGlyphs);
 
     expect(result.statuses[0].status).toBe('found');
-    // 既存の found が保持される（新しいスキャンで上書き）
+    // 後の status オブジェクト（pageIndex=7）に置き換わっている
+    expect(result.statuses[0].pageIndex).toBe(7);
     expect(result.glyphs).toHaveLength(1);
+    // 新しいグリフが採用されている
+    expect(result.glyphs[0].advanceWidth).toBe(1200);
   });
 
   it('alt-variant もベースグリフが上書きされたら除外する', () => {
     const prevStatuses = [makeStatus('あ', 'imported')];
     const prevGlyphs = [makeGlyph('あ'), makeGlyph('あ', 1)];
+    const newStatuses = [makeStatus('あ', 'found')];
+    const newGlyphs = [makeGlyph('あ')];
+
+    const result = mergeScanIntoExisting(prevStatuses, prevGlyphs, newStatuses, newGlyphs);
+
+    expect(result.glyphs).toHaveLength(1);
+    expect(result.glyphs[0].name).toBe('uni3042');
+    expect(result.glyphs.find((g) => g.name.includes('.alt'))).toBeUndefined();
+  });
+
+  it('画像由来 (found) の alt も後勝ちで上書きされて除外される (Issue #93)', () => {
+    // 既存: 画像由来のベース + alt1
+    const prevStatuses = [makeStatus('あ', 'found')];
+    const prevGlyphs = [makeGlyph('あ'), makeGlyph('あ', 1)];
+    // 新スキャン: ベースのみ（alt なし）
     const newStatuses = [makeStatus('あ', 'found')];
     const newGlyphs = [makeGlyph('あ')];
 


### PR DESCRIPTION
## 関連 Issue
closes #93

## 変更内容

### `src/lib/merge.ts` - `mergeScanIntoExisting`
新規 found が既存 found も上書き対象に含める後勝ちに変更。
（既存挙動は先勝ち = 同じ unicode の画像を再スキャンしても反映されなかった）

### `src/lib/scanner/processor.ts`
同一アップロード内で同じ unicode が複数検出されても、ベースグリフは Map で後勝ち上書き。
alt グリフはベース上書き時に対応する旧 alt（`uni{HEX}.alt*` プレフィックス一致）を破棄。

### `src/lib/merge.ts` - `mergeImportIntoExisting`
既存挙動「empty のみ imported で埋める / found は守る」が #93 仕様と一致するため変更なし。テストで挙動を固定。

## マージ優先順位（#93 確定仕様）

| 新規 ↔ 既存 | 挙動 |
|---|---|
| 画像 → 空 | 採用 |
| 画像 → 画像由来 | **後勝ち** |
| 画像 → TTF由来 | 画像で上書き |
| TTF → 空 | 採用 |
| TTF → 画像由来 | 無視（既存維持） |
| TTF → TTF由来 | 後勝ち |

由来メタは既存の `GlyphStatus.status` ('found' = 画像 / 'imported' = TTF) で識別。

## テスト
- `npm test`: 5ファイル / 48テスト 全PASS
- `npm run lint`: 無警告