### PR TITLE
合成テンプレート画像でスキャン〜フォント生成の golden path を自動検証する (#109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 
 # Test fixtures (generated at test time)
 tests/fixtures/mock-scans/
+tests/fixtures/mock-scans-distorted/
 tests/fixtures/test-output.ttf
 
 # Playwright

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 tests/fixtures/mock-scans/
 tests/fixtures/mock-scans-distorted/
 tests/fixtures/test-output.ttf
+tests/fixtures/test-blank-page.png
+tests/fixtures/test-upload*.zip
 
 # Playwright
 test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ npm test
 # テスト（ウォッチモード）
 npm run test:watch
 
-# 模擬スキャン画像の再生成
+# 模擬スキャン画像の再生成（正面 + 斜め撮影風の歪みバリアント、#109）
 npm run test:generate-fixtures
 
 # リント（ESLint）

--- a/docs/image-processing.md
+++ b/docs/image-processing.md
@@ -400,6 +400,6 @@ Phase 3: フォント生成
 
 スキャン失敗時にどの段階で落ちたか console から判別できる。
 
-- TS 側（`src/lib/scanner/processor.ts`）: `[scan:{stage}] ...` 形式。stage は `pipeline` / `marker` / `dpi` / `perspective` / `qr` / `chars` / `cells` / `vectorize` / `font-input`。WASM エラーはエラー文言から失敗段階を推定する（`inferFailedStage`）
+- TS 側（`src/lib/scanner/processor.ts`）: `[scan:{stage}] ...` 形式。stage は `pipeline` / `marker` / `dpi` / `perspective` / `decode` / `qr` / `chars` / `cells` / `vectorize` / `font-input`、および文言から段階を推定できない WASM エラーのフォールバック `wasm`。WASM エラーはエラー文言から失敗段階を推定する（`inferFailedStage`）
 - WASM 側（Rust `log!`）: `=== ステップN: ... ===` 形式で内部段階（二値化・マーカー検出・ホモグラフィー・QR・セル切り出し等）を出力
 - e2e は `page.on('console')` で両方を収集し、テスト失敗時に添付（`scan-stage-logs`）+ コンソール出力する

--- a/docs/image-processing.md
+++ b/docs/image-processing.md
@@ -366,3 +366,40 @@ Phase 3: フォント生成
 - 1ページずつ処理してプログレスバー更新
 - 必要に応じてWeb Worker使用（UIブロック防止）
 - 将来的にはOpenCV.js → WebAssembly（Rust）で高速化
+
+---
+
+## テスト用合成スキャン画像（#109）
+
+印刷・手書き・カメラ撮影の実物ループなしで、スキャンパイプラインの成否を高速に検証するための合成フィクスチャ。`npm run test:generate-fixtures`（`tests/fixtures/generate-mock-scans.ts`）で生成する。`npm run test:e2e` は生成を内包している。
+
+### 正面画像
+
+- 出力先: `tests/fixtures/mock-scans/page-NN.png`
+- テンプレートPDFと同一レイアウト（layout.ts の定数を import）を node-canvas で描画し、各セルにひらがな83文字をフォント描画する。QR・四隅マーカー・グレースケールバー・シアン要素も含む
+- 文字リストは `src/data/characters.ts` の `HIRAGANA` が正本（二重管理しない）
+
+### 歪みバリアント（斜め撮影風）
+
+- 出力先: `tests/fixtures/mock-scans-distorted/page-NN-{variant}.png`
+- 実装: `tests/fixtures/distort.ts`。4隅対応点からホモグラフィ（8自由度）を解き、出力→入力の逆写像 + バイリニア補間で射影変換する（node-canvas は台形変形を直接サポートしないため）。パラメータは `cli/src/distort.rs` と同系統
+
+| バリアント    | 内容                                                            |
+| ------------- | --------------------------------------------------------------- |
+| `perspective` | 台形変形（上辺を狭く、強さ0.05）+ グレー背景 + 余白200px        |
+| `rotated`     | 3°回転 + グレー背景 + 余白200px                                 |
+| `combined`    | 2°回転 + 台形0.03 + 縮小0.92 + 明度ムラ + 3x3ぼかし + 余白200px |
+
+### e2e での検証
+
+- `tests/e2e/full-flow.spec.ts`: 正面画像2ページ → ひらがな83文字全部の TTF グリフ存在（index > 0）と非空パス（`path.commands.length > 0`）を検証
+- `tests/e2e/distorted-flow.spec.ts`: 歪みバリアントを ZIP アップロードし、台形補正を通してフォント生成まで到達することを検証
+- 共通ヘルパー: `tests/e2e/font-flow-utils.ts`
+
+### 段階診断ログ
+
+スキャン失敗時にどの段階で落ちたか console から判別できる。
+
+- TS 側（`src/lib/scanner/processor.ts`）: `[scan:{stage}] ...` 形式。stage は `pipeline` / `marker` / `dpi` / `perspective` / `qr` / `chars` / `cells` / `vectorize` / `font-input`。WASM エラーはエラー文言から失敗段階を推定する（`inferFailedStage`）
+- WASM 側（Rust `log!`）: `=== ステップN: ... ===` 形式で内部段階（二値化・マーカー検出・ホモグラフィー・QR・セル切り出し等）を出力
+- e2e は `page.on('console')` で両方を収集し、テスト失敗時に添付（`scan-stage-logs`）+ コンソール出力する

--- a/src/lib/scanner/processor.ts
+++ b/src/lib/scanner/processor.ts
@@ -54,6 +54,37 @@ function correctedImageToCanvas(
 }
 
 /**
+ * 段階診断ログ（#109）。
+ * スキャンパイプラインのどの段階まで到達したか／どこで落ちたかを
+ * console から判別できるようにする。UI の挙動には影響しない。
+ * WASM 内部の詳細ログ（`=== ステップN ===`）と併せて読む。
+ */
+function scanLog(stage: string, message: string, failed = false): void {
+  const line = `[scan:${stage}] ${message}`;
+  if (failed) {
+    console.error(line);
+  } else {
+    console.info(line);
+  }
+}
+
+/**
+ * WASM エラーメッセージから、パイプラインのどの段階で失敗したかを推定する。
+ * Rust 側のエラー文言（marker.rs / pipeline.rs）に依存する。
+ */
+export function inferFailedStage(rawError: string): string {
+  if (rawError.includes('マーカー')) return 'marker';
+  if (rawError.includes('解像度') || rawError.includes('DPI')) return 'dpi';
+  if (rawError.includes('歪み') || rawError.includes('撮り直し')) return 'perspective';
+  if (
+    rawError.includes('画像') &&
+    (rawError.includes('デコード') || rawError.includes('フォーマット'))
+  )
+    return 'decode';
+  return 'wasm';
+}
+
+/**
  * WASMからのエラーメッセージをユーザーフレンドリーな日本語に変換する。
  * `buildSha` が渡された場合はエラー末尾に `[build: sha]` を付加し、報告時に版特定を容易にする。
  * 省略時は純粋な変換のみ行う（テスト容易性のため副作用なし）。
@@ -114,15 +145,16 @@ export async function processImages(
 
   for (let fi = 0; fi < imageFiles.length; fi++) {
     callbacks.onPageStart(fi + 1, imageFiles.length);
+    const fileName = imageFiles[fi].name;
+    scanLog('pipeline', `file="${fileName}" (${fi + 1}/${imageFiles.length}) 開始`);
 
     let wasmResult;
     try {
       wasmResult = await processImageWasm(imageFiles[fi]);
     } catch (e) {
-      const msg = translateWasmError(
-        e instanceof Error ? e.message : String(e),
-        getWasmBuildInfo()?.sha,
-      );
+      const rawError = e instanceof Error ? e.message : String(e);
+      scanLog(inferFailedStage(rawError), `file="${fileName}" 失敗: ${rawError}`, true);
+      const msg = translateWasmError(rawError, getWasmBuildInfo()?.sha);
       callbacks.onMessage({
         type: 'error',
         text: `ファイル "${imageFiles[fi].name}" の処理に失敗しました: ${msg}`,
@@ -130,14 +162,22 @@ export async function processImages(
       continue;
     }
 
+    // WASM 成功 = マーカー検出・台形補正・セル切り出し・二値化・ベクター化は完走している
+    scanLog(
+      'perspective',
+      `file="${fileName}" ok corrected=${wasmResult.corrected_width}x${wasmResult.corrected_height}`,
+    );
+
     const pageNumber = wasmResult.page_number;
     if (!pageNumber) {
+      scanLog('qr', `file="${fileName}" 失敗: QR からページ番号を取得できない`, true);
       callbacks.onMessage({
         type: 'error',
         text: `画像 ${fi + 1} のQRコードを読み取れませんでした。画像が不鮮明な可能性があります。`,
       });
       continue;
     }
+    scanLog('qr', `file="${fileName}" ok page=${pageNumber}/${wasmResult.total_pages ?? '?'}`);
 
     // Issue #96: リトライ用 PDF は QR に文字リスト (`chars`) を直接埋め込むため、
     // それを最優先で使う。CharSelection に当てはまらない任意文字リストでも復元できる。
@@ -145,10 +185,16 @@ export async function processImages(
     let pageChars: string[];
     if (wasmResult.qr_chars && wasmResult.qr_chars.length > 0) {
       pageChars = wasmResult.qr_chars;
+      scanLog('chars', `page=${pageNumber} ok count=${pageChars.length} source=qr_chars`);
     } else {
       const selectionFlag = wasmResult.char_selection;
       const selection = selectionFlag ? flagToSelection(selectionFlag) : null;
       if (!selection) {
+        scanLog(
+          'chars',
+          `page=${pageNumber} 失敗: 文字セット選択フラグを復元できない (s=${selectionFlag ?? 'null'})`,
+          true,
+        );
         callbacks.onMessage({
           type: 'error',
           text: `画像 ${fi + 1} のQRから文字セット情報を取得できませんでした。古い版のテンプレートの可能性があります。PDF を再生成して印刷してください。`,
@@ -156,6 +202,10 @@ export async function processImages(
         continue;
       }
       pageChars = getCharactersForPage(pageNumber - 1, selection);
+      scanLog(
+        'chars',
+        `page=${pageNumber} ok count=${pageChars.length} source=selection(${selectionFlag})`,
+      );
     }
 
     // 補正後キャンバスをコールバックで通知
@@ -175,6 +225,17 @@ export async function processImages(
       if (!cellsByPos.has(key)) cellsByPos.set(key, []);
       cellsByPos.get(key)!.push(cell);
     }
+
+    const totalCells = wasmResult.cells.length;
+    const adoptedCellCount = wasmResult.cells.filter((c) => c.adopted).length;
+    const emptyCellCount = wasmResult.cells.filter((c) => c.is_empty).length;
+    scanLog(
+      'cells',
+      `page=${pageNumber} ok cells=${totalCells} adopted=${adoptedCellCount} empty=${emptyCellCount}`,
+    );
+
+    let pageGlyphCount = 0;
+    let pageEmptyPathCount = 0; // 採用されたのにベクター化結果が空のセル数
 
     for (const [, cells] of cellsByPos) {
       const firstCell = cells[0];
@@ -233,10 +294,20 @@ export async function processImages(
         }
       }
 
+      pageGlyphCount++;
+
       for (let ai = 0; ai < adoptedCells.length; ai++) {
         const cell = adoptedCells[ai];
         // ベクター化は Rust 側で完結済み。WASM 出力の paths をそのまま使う
         const paths = cell.paths;
+        if (paths.length === 0) {
+          pageEmptyPathCount++;
+          scanLog(
+            'vectorize',
+            `page=${pageNumber} char="${char}" (row=${cell.row},col=${cell.col}) 採用セルのパスが空`,
+            true,
+          );
+        }
 
         const name =
           ai === 0
@@ -258,7 +329,14 @@ export async function processImages(
         }
       }
     }
+
+    scanLog(
+      'vectorize',
+      `page=${pageNumber} ok glyphs=${pageGlyphCount} emptyPaths=${pageEmptyPathCount}`,
+      pageEmptyPathCount > 0,
+    );
   }
 
+  scanLog('font-input', `ok base=${baseGlyphs.size} alt=${altGlyphs.length}`);
   return { glyphs: [...baseGlyphs.values(), ...altGlyphs] };
 }

--- a/tests/e2e/distorted-flow.spec.ts
+++ b/tests/e2e/distorted-flow.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * 歪み合成スキャン e2e（#109）
+ *
+ * 斜め撮影風に歪ませた合成テンプレート画像（tests/fixtures/mock-scans-distorted/）を
+ * アップロードし、QR/マーカー検出 → 台形補正 → セル切り出し → 二値化 → ベクター化 →
+ * フォント生成の golden path が通ることを検証する。
+ *
+ * バリアント（tests/fixtures/distort.ts の DISTORT_VARIANTS）:
+ * - perspective: 台形変形（上辺が狭い）+ グレー背景 + 余白
+ * - rotated:     3° 回転 + グレー背景 + 余白
+ * - combined:    軽い回転 + 軽い台形 + 縮小 + 明度ムラ + 軽いぼかし
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { HIRAGANA, CHARS_PER_PAGE } from '../../src/data/characters';
+import {
+  createZipFromFiles,
+  expectGlyphsForChars,
+  loadFont,
+  runScanToFontFlow,
+  withStageLogs,
+} from './font-flow-utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DISTORTED_DIR = path.join(__dirname, '..', 'fixtures', 'mock-scans-distorted');
+
+// ページ1に描画される文字（HIRAGANA の先頭 CHARS_PER_PAGE 文字）
+const PAGE1_CHARS = HIRAGANA.slice(0, CHARS_PER_PAGE);
+
+test.describe('歪み合成スキャン: 台形補正を通してフォント生成まで到達する', () => {
+  test('台形変形（perspective）の全ページから83文字全部を抽出できる', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(300_000);
+
+    const files = fs
+      .readdirSync(DISTORTED_DIR)
+      .filter((f) => f.endsWith('-perspective.png'))
+      .sort()
+      .map((f) => path.join(DISTORTED_DIR, f));
+    expect(files.length).toBeGreaterThanOrEqual(2);
+
+    const zipPath = path.join(DISTORTED_DIR, '..', 'test-upload-perspective.zip');
+    await createZipFromFiles(files, zipPath);
+
+    try {
+      await withStageLogs(page, testInfo, async () => {
+        const fontPath = await runScanToFontFlow(page, zipPath);
+        const font = loadFont(fontPath);
+        expectGlyphsForChars(font, HIRAGANA);
+      });
+    } finally {
+      if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);
+    }
+  });
+
+  test('回転（rotated）の1ページからページ1の全文字を抽出できる', async ({ page }, testInfo) => {
+    test.setTimeout(300_000);
+
+    const zipPath = path.join(DISTORTED_DIR, '..', 'test-upload-rotated.zip');
+    await createZipFromFiles([path.join(DISTORTED_DIR, 'page-01-rotated.png')], zipPath);
+
+    try {
+      await withStageLogs(page, testInfo, async () => {
+        const fontPath = await runScanToFontFlow(page, zipPath);
+        const font = loadFont(fontPath);
+        expectGlyphsForChars(font, PAGE1_CHARS);
+      });
+    } finally {
+      if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);
+    }
+  });
+
+  test('複合歪み（combined）の1ページからページ1の全文字を抽出できる', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(300_000);
+
+    const zipPath = path.join(DISTORTED_DIR, '..', 'test-upload-combined.zip');
+    await createZipFromFiles([path.join(DISTORTED_DIR, 'page-01-combined.png')], zipPath);
+
+    try {
+      await withStageLogs(page, testInfo, async () => {
+        const fontPath = await runScanToFontFlow(page, zipPath);
+        const font = loadFont(fontPath);
+        expectGlyphsForChars(font, PAGE1_CHARS);
+      });
+    } finally {
+      if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);
+    }
+  });
+});

--- a/tests/e2e/failed-scan.spec.ts
+++ b/tests/e2e/failed-scan.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * 失敗系スキャン e2e（#109）
+ *
+ * マーカーの無い完全に真っ白な A4 相当画像をアップロードし、
+ * - UI にユーザー向けエラーメッセージ（撮影ガイド付き）が表示されること
+ * - 段階診断ログに `[scan:marker]` のエラー行が出ること（inferFailedStage の実配線）
+ * を検証する。マーカー検出はパイプラインの早い段階なので軽量に落ちる。
+ *
+ * 注意: 「正面フィクスチャのマーカー円だけ白塗り」方式は使わない。
+ * マーカー検出（cli/src/marker.rs）が探索領域内に残る印刷内容（タイトル文字・
+ * マスの罫線など）のブロブをマーカーと誤検出してパイプラインが先へ進み、
+ * QR 段階のエラー「QRコードを読み取れませんでした」に化けてしまうため（製品側の課題 #115）。
+ * 真っ白な画像なら探索領域にブロブが1つも無く、
+ * 「TopLeft マーカーが検出できませんでした（ブロブ数=0, フィルタ通過=0）」で決定論的に落ちる。
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createCanvas } from 'canvas';
+import { createZipFromFiles, withStageLogs } from './font-flow-utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+
+/** 完全に真っ白な A4 相当（300dpi: 2480x3508）の PNG を作る */
+function createBlankScan(outPath: string): void {
+  const canvas = createCanvas(2480, 3508);
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#FFFFFF';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  fs.writeFileSync(outPath, canvas.toBuffer('image/png'));
+}
+
+test.describe('失敗系スキャン: マーカー欠落', () => {
+  test('マーカー欠落画像でUIエラー表示と [scan:marker] エラーログが出る', async ({
+    page,
+  }, testInfo) => {
+    const blankPng = path.join(FIXTURES_DIR, 'test-blank-page.png');
+    const zipPath = path.join(FIXTURES_DIR, 'test-upload-blank.zip');
+    createBlankScan(blankPng);
+    await createZipFromFiles([blankPng], zipPath);
+
+    try {
+      const { logs } = await withStageLogs(page, testInfo, async () => {
+        await page.goto('/');
+        await page.getByRole('link', { name: '2. フォント作成', exact: true }).click();
+        await expect(page.locator('h2')).toContainText('フォントを作成する');
+
+        await page.locator('#zip-input').setInputFiles(zipPath);
+
+        // UI にユーザー向けエラーメッセージ（translateWasmError の撮影ガイド）が出る
+        await expect(page.locator('.message--error')).toContainText(
+          'マーカーを検出できませんでした',
+          { timeout: 120_000 },
+        );
+      });
+
+      // 段階診断ログ: marker 段階のエラーとして console.error に出ている
+      const markerErrors = logs.filter(
+        (l) => l.type === 'error' && l.text.startsWith('[scan:marker]'),
+      );
+      expect(markerErrors.length, '[scan:marker] エラーログがない').toBeGreaterThan(0);
+    } finally {
+      if (fs.existsSync(blankPng)) fs.unlinkSync(blankPng);
+      if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);
+    }
+  });
+});

--- a/tests/e2e/failed-scan.spec.ts
+++ b/tests/e2e/failed-scan.spec.ts
@@ -44,25 +44,28 @@ test.describe('失敗系スキャン: マーカー欠落', () => {
     await createZipFromFiles([blankPng], zipPath);
 
     try {
-      const { logs } = await withStageLogs(page, testInfo, async () => {
+      await withStageLogs(page, testInfo, async (logs) => {
         await page.goto('/');
         await page.getByRole('link', { name: '2. フォント作成', exact: true }).click();
         await expect(page.locator('h2')).toContainText('フォントを作成する');
 
         await page.locator('#zip-input').setInputFiles(zipPath);
 
-        // UI にユーザー向けエラーメッセージ（translateWasmError の撮影ガイド）が出る
+        // UI にユーザー向けエラーメッセージ（translateWasmError の撮影ガイド）が出る。
+        // timeout は test timeout（120s）より十分短くし、遅い環境でも expect 側の
+        // 明確なメッセージで落ちるようにする（実測 2〜3 秒で表示される）
         await expect(page.locator('.message--error')).toContainText(
           'マーカーを検出できませんでした',
-          { timeout: 120_000 },
+          { timeout: 30_000 },
         );
-      });
 
-      // 段階診断ログ: marker 段階のエラーとして console.error に出ている
-      const markerErrors = logs.filter(
-        (l) => l.type === 'error' && l.text.startsWith('[scan:marker]'),
-      );
-      expect(markerErrors.length, '[scan:marker] エラーログがない').toBeGreaterThan(0);
+        // 段階診断ログ: marker 段階のエラーとして console.error に出ている。
+        // fn 内で検証することで、この検証だけが失敗した場合も scan-stage-logs 添付が付く
+        const markerErrors = logs.filter(
+          (l) => l.type === 'error' && l.text.startsWith('[scan:marker]'),
+        );
+        expect(markerErrors.length, '[scan:marker] エラーログがない').toBeGreaterThan(0);
+      });
     } finally {
       if (fs.existsSync(blankPng)) fs.unlinkSync(blankPng);
       if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);

--- a/tests/e2e/font-flow-utils.ts
+++ b/tests/e2e/font-flow-utils.ts
@@ -1,0 +1,117 @@
+/**
+ * e2e 共通ユーティリティ: ZIP アップロード → スキャン → フォント生成 → TTF 検証（#109）
+ *
+ * full-flow.spec.ts（正面画像）と distorted-flow.spec.ts（歪み画像）で共用する。
+ */
+
+import { expect, type Page, type TestInfo } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import JSZip from 'jszip';
+import opentype from 'opentype.js';
+
+/** 画像ファイル群を ZIP にまとめて zipPath に書き出す */
+export async function createZipFromFiles(filePaths: string[], zipPath: string): Promise<void> {
+  const zip = new JSZip();
+  for (const filePath of filePaths) {
+    zip.file(path.basename(filePath), fs.readFileSync(filePath));
+  }
+  const buf = await zip.generateAsync({ type: 'nodebuffer' });
+  fs.writeFileSync(zipPath, buf);
+}
+
+/**
+ * 段階診断ログを収集しながら fn を実行する。
+ * 失敗時は `[scan:*]`（processor.ts）と `=== ステップN ===`（WASM 内部）の
+ * ログをテスト添付 + コンソールに出力し、どの段階で落ちたか特定できるようにする。
+ */
+export async function withStageLogs<T>(
+  page: Page,
+  testInfo: TestInfo,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const logs: string[] = [];
+  page.on('console', (msg) => {
+    const text = msg.text();
+    if (text.startsWith('[scan:') || text.startsWith('===')) {
+      logs.push(text);
+    }
+  });
+  try {
+    return await fn();
+  } catch (e) {
+    await testInfo.attach('scan-stage-logs', {
+      body: logs.length > 0 ? logs.join('\n') : '(段階ログなし)',
+      contentType: 'text/plain',
+    });
+    console.error('--- scan stage logs (tail) ---');
+    for (const line of logs.slice(-60)) console.error(line);
+    throw e;
+  }
+}
+
+/**
+ * フォント作成ページで ZIP をアップロードし、スキャン → フォント生成 → TTF
+ * ダウンロードまで実行して、ダウンロードされた TTF のパスを返す。
+ */
+export async function runScanToFontFlow(page: Page, zipPath: string): Promise<string> {
+  await page.goto('/');
+
+  // フォント作成ページへ遷移（#98: ヘッダー nav は <a> リンク化済み）
+  await page.getByRole('link', { name: '2. フォント作成', exact: true }).click();
+  await expect(page.locator('h2')).toContainText('フォントを作成する');
+
+  // ZIPをアップロード（hidden input に直接セット）
+  await page.locator('#zip-input').setInputFiles(zipPath);
+
+  // スキャン処理の完了を待つ（review フェーズのボタンが出る）
+  await expect(page.locator('button', { hasText: /フォントを生成|このまま生成/ })).toBeVisible({
+    timeout: 180_000,
+  });
+
+  await page.click('button:has-text("フォントを生成"), button:has-text("このまま生成")');
+
+  // フォント生成完了を待つ
+  await expect(page.locator('text=フォントが完成しました')).toBeVisible({ timeout: 90_000 });
+
+  // TTFダウンロード
+  const downloadPromise = page.waitForEvent('download');
+  await page.click('text=フォントをダウンロード');
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toMatch(/\.ttf$/);
+  const downloadPath = await download.path();
+  expect(downloadPath).toBeTruthy();
+  return downloadPath!;
+}
+
+/** TTF ファイルを opentype.js で読み込む */
+export function loadFont(fontPath: string): opentype.Font {
+  const fontBuffer = fs.readFileSync(fontPath);
+  const arrayBuffer = fontBuffer.buffer.slice(
+    fontBuffer.byteOffset,
+    fontBuffer.byteOffset + fontBuffer.byteLength,
+  );
+  return opentype.parse(arrayBuffer);
+}
+
+/**
+ * 期待文字の全てについて、グリフが存在し（.notdef でない）かつ
+ * パスが空でないことを検証する。
+ */
+export function expectGlyphsForChars(font: opentype.Font, chars: string[]): void {
+  const missing: string[] = [];
+  const emptyPath: string[] = [];
+  for (const char of chars) {
+    const glyph = font.charToGlyph(char);
+    if (!glyph || glyph.index === 0) {
+      missing.push(char);
+      continue;
+    }
+    if (!glyph.path || glyph.path.commands.length === 0) {
+      emptyPath.push(char);
+    }
+  }
+  expect(missing, `グリフが見つからない文字: ${missing.join('')}`).toEqual([]);
+  expect(emptyPath, `パスが空の文字: ${emptyPath.join('')}`).toEqual([]);
+}

--- a/tests/e2e/font-flow-utils.ts
+++ b/tests/e2e/font-flow-utils.ts
@@ -20,32 +20,40 @@ export async function createZipFromFiles(filePaths: string[], zipPath: string): 
   fs.writeFileSync(zipPath, buf);
 }
 
+/** 収集した段階診断ログ1行。type は console のレベル（'error' / 'info' など） */
+export interface StageLogEntry {
+  type: string;
+  text: string;
+}
+
 /**
  * 段階診断ログを収集しながら fn を実行する。
  * 失敗時は `[scan:*]`（processor.ts）と `=== ステップN ===`（WASM 内部）の
  * ログをテスト添付 + コンソールに出力し、どの段階で落ちたか特定できるようにする。
+ * 成功時も収集済みログを返すので、呼び出し側で段階ログ自体を検証できる。
  */
 export async function withStageLogs<T>(
   page: Page,
   testInfo: TestInfo,
   fn: () => Promise<T>,
-): Promise<T> {
-  const logs: string[] = [];
+): Promise<{ result: T; logs: StageLogEntry[] }> {
+  const logs: StageLogEntry[] = [];
   page.on('console', (msg) => {
     const text = msg.text();
     if (text.startsWith('[scan:') || text.startsWith('===')) {
-      logs.push(text);
+      logs.push({ type: msg.type(), text });
     }
   });
   try {
-    return await fn();
+    const result = await fn();
+    return { result, logs };
   } catch (e) {
     await testInfo.attach('scan-stage-logs', {
-      body: logs.length > 0 ? logs.join('\n') : '(段階ログなし)',
+      body: logs.length > 0 ? logs.map((l) => l.text).join('\n') : '(段階ログなし)',
       contentType: 'text/plain',
     });
     console.error('--- scan stage logs (tail) ---');
-    for (const line of logs.slice(-60)) console.error(line);
+    for (const { text } of logs.slice(-60)) console.error(text);
     throw e;
   }
 }

--- a/tests/e2e/font-flow-utils.ts
+++ b/tests/e2e/font-flow-utils.ts
@@ -4,7 +4,7 @@
  * full-flow.spec.ts（正面画像）と distorted-flow.spec.ts（歪み画像）で共用する。
  */
 
-import { expect, type Page, type TestInfo } from '@playwright/test';
+import { expect, type ConsoleMessage, type Page, type TestInfo } from '@playwright/test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import JSZip from 'jszip';
@@ -39,7 +39,7 @@ export async function withStageLogs<T>(
   fn: (logs: StageLogEntry[]) => Promise<T>,
 ): Promise<{ result: T; logs: StageLogEntry[] }> {
   const logs: StageLogEntry[] = [];
-  const onConsole = (msg: { type(): string; text(): string }) => {
+  const onConsole = (msg: ConsoleMessage) => {
     const text = msg.text();
     if (text.startsWith('[scan:') || text.startsWith('===')) {
       logs.push({ type: msg.type(), text });

--- a/tests/e2e/font-flow-utils.ts
+++ b/tests/e2e/font-flow-utils.ts
@@ -30,22 +30,24 @@ export interface StageLogEntry {
  * 段階診断ログを収集しながら fn を実行する。
  * 失敗時は `[scan:*]`（processor.ts）と `=== ステップN ===`（WASM 内部）の
  * ログをテスト添付 + コンソールに出力し、どの段階で落ちたか特定できるようにする。
- * 成功時も収集済みログを返すので、呼び出し側で段階ログ自体を検証できる。
+ * fn には収集中のログ配列を渡す。段階ログ自体の検証は fn 内で行うこと
+ * （fn 内での失敗なら scan-stage-logs 添付が付く）。成功時も収集済みログを返す。
  */
 export async function withStageLogs<T>(
   page: Page,
   testInfo: TestInfo,
-  fn: () => Promise<T>,
+  fn: (logs: StageLogEntry[]) => Promise<T>,
 ): Promise<{ result: T; logs: StageLogEntry[] }> {
   const logs: StageLogEntry[] = [];
-  page.on('console', (msg) => {
+  const onConsole = (msg: { type(): string; text(): string }) => {
     const text = msg.text();
     if (text.startsWith('[scan:') || text.startsWith('===')) {
       logs.push({ type: msg.type(), text });
     }
-  });
+  };
+  page.on('console', onConsole);
   try {
-    const result = await fn();
+    const result = await fn(logs);
     return { result, logs };
   } catch (e) {
     await testInfo.attach('scan-stage-logs', {
@@ -55,6 +57,9 @@ export async function withStageLogs<T>(
     console.error('--- scan stage logs (tail) ---');
     for (const { text } of logs.slice(-60)) console.error(text);
     throw e;
+  } finally {
+    // 同一 page で複数回使ったときに listener が残って二重収集になるのを防ぐ
+    page.off('console', onConsole);
   }
 }
 

--- a/tests/e2e/full-flow.spec.ts
+++ b/tests/e2e/full-flow.spec.ts
@@ -2,30 +2,18 @@ import { test, expect } from '@playwright/test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import JSZip from 'jszip';
-import opentype from 'opentype.js';
+import { HIRAGANA } from '../../src/data/characters';
+import {
+  createZipFromFiles,
+  expectGlyphsForChars,
+  loadFont,
+  runScanToFontFlow,
+  withStageLogs,
+} from './font-flow-utils';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const MOCK_SCANS_DIR = path.join(__dirname, '..', 'fixtures', 'mock-scans');
-
-/**
- * 模擬スキャン画像3枚をZIPにまとめる
- */
-async function createMockZip(): Promise<Buffer> {
-  const zip = new JSZip();
-  const files = fs.readdirSync(MOCK_SCANS_DIR).filter((f) => f.endsWith('.png'));
-  // ひらがな83文字は 2 ページに収まる（generate-mock-scans.ts の出力枚数と一致）
-  expect(files.length).toBeGreaterThanOrEqual(2);
-
-  for (const file of files) {
-    const data = fs.readFileSync(path.join(MOCK_SCANS_DIR, file));
-    zip.file(file, data);
-  }
-
-  const buf = await zip.generateAsync({ type: 'nodebuffer' });
-  return buf;
-}
 
 test.describe('フルフロー: テンプレート→スキャン→フォント生成', () => {
   test('テンプレートPDFをダウンロードできる', async ({ page }) => {
@@ -65,70 +53,34 @@ test.describe('フルフロー: テンプレート→スキャン→フォント
     expect(stat.size).toBeGreaterThan(5000);
   });
 
-  test('模擬スキャン画像をアップロードしてフォントを生成できる', async ({ page }) => {
-    await page.goto('/');
+  test('模擬スキャン画像をアップロードしてフォントを生成できる', async ({ page }, testInfo) => {
+    test.setTimeout(300_000);
 
-    // フォント作成ページへ遷移（#98: ヘッダー nav は <a> リンク化済み）
-    await page.getByRole('link', { name: '2. フォント作成', exact: true }).click();
-    await expect(page.locator('h2')).toContainText('フォントを作成する');
+    // ZIPファイルを作成（正面画像の全ページ）
+    const files = fs
+      .readdirSync(MOCK_SCANS_DIR)
+      .filter((f) => f.endsWith('.png'))
+      .sort()
+      .map((f) => path.join(MOCK_SCANS_DIR, f));
+    // ひらがな83文字は 2 ページに収まる（generate-mock-scans.ts の出力枚数と一致）
+    expect(files.length).toBeGreaterThanOrEqual(2);
 
-    // ZIPファイルを作成
-    const zipBuffer = await createMockZip();
     const zipPath = path.join(MOCK_SCANS_DIR, '..', 'test-upload.zip');
-    fs.writeFileSync(zipPath, zipBuffer);
+    await createZipFromFiles(files, zipPath);
 
     try {
-      // ZIPをアップロード（hidden input に直接セット）
-      const fileInput = page.locator('#zip-input');
-      await fileInput.setInputFiles(zipPath);
+      await withStageLogs(page, testInfo, async () => {
+        const fontPath = await runScanToFontFlow(page, zipPath);
 
-      // スキャン処理の完了を待つ（review フェーズ）
-      // プログレスバーが表示され、その後 review フェーズのボタンが出る
-      await expect(page.locator('button', { hasText: /フォントを生成|このまま生成/ })).toBeVisible({
-        timeout: 90_000,
+        // TTFファイルサイズ確認
+        const stat = fs.statSync(fontPath);
+        expect(stat.size).toBeGreaterThan(1000);
+
+        // フィクスチャに描画した全ひらがな83文字について、
+        // グリフが存在し（index > 0）かつパスが空でないことを検証する
+        const font = loadFont(fontPath);
+        expectGlyphsForChars(font, HIRAGANA);
       });
-
-      // 「フォントを生成する」または「このまま生成する」ボタンをクリック
-      await page.click('button:has-text("フォントを生成"), button:has-text("このまま生成")');
-
-      // フォント生成完了を待つ
-      await expect(page.locator('text=フォントが完成しました')).toBeVisible({
-        timeout: 90_000,
-      });
-
-      // TTFダウンロード
-      const downloadPromise = page.waitForEvent('download');
-      await page.click('text=フォントをダウンロード');
-      const download = await downloadPromise;
-
-      expect(download.suggestedFilename()).toMatch(/\.ttf$/);
-      const downloadPath = await download.path();
-      expect(downloadPath).toBeTruthy();
-
-      // TTFファイルサイズ確認
-      const stat = fs.statSync(downloadPath!);
-      expect(stat.size).toBeGreaterThan(1000);
-
-      // opentype.js でフォントを読み込み、ひらがなグリフを検証
-      const fontBuffer = fs.readFileSync(downloadPath!);
-      const arrayBuffer = fontBuffer.buffer.slice(
-        fontBuffer.byteOffset,
-        fontBuffer.byteOffset + fontBuffer.byteLength,
-      );
-      const font = opentype.parse(arrayBuffer);
-
-      // ひらがな「あ」のグリフが存在するか
-      const glyphA = font.charToGlyph('あ');
-      expect(glyphA).toBeTruthy();
-      // .notdef (index 0) でなければ実際のグリフがある
-      expect(glyphA.index).toBeGreaterThan(0);
-
-      // 複数のひらがなを検証
-      const testChars = ['あ', 'い', 'う', 'か', 'さ'];
-      for (const char of testChars) {
-        const glyph = font.charToGlyph(char);
-        expect(glyph.index, `グリフが見つからない: ${char}`).toBeGreaterThan(0);
-      }
     } finally {
       // テスト用ZIPを削除
       if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);

--- a/tests/e2e/full-flow.spec.ts
+++ b/tests/e2e/full-flow.spec.ts
@@ -69,7 +69,7 @@ test.describe('フルフロー: テンプレート→スキャン→フォント
     await createZipFromFiles(files, zipPath);
 
     try {
-      const { logs } = await withStageLogs(page, testInfo, async () => {
+      await withStageLogs(page, testInfo, async (logs) => {
         const fontPath = await runScanToFontFlow(page, zipPath);
 
         // TTFファイルサイズ確認
@@ -80,16 +80,18 @@ test.describe('フルフロー: テンプレート→スキャン→フォント
         // グリフが存在し（index > 0）かつパスが空でないことを検証する
         const font = loadFont(fontPath);
         expectGlyphsForChars(font, HIRAGANA);
-      });
 
-      // 段階診断ログ（#109）: golden path 成功時は最終段階 font-input まで ok で到達し、
-      // 途中段階のエラーログ（[scan:*] の console.error）が1件も出ていないこと
-      expect(
-        logs.some((l) => l.text.startsWith('[scan:font-input] ok')),
-        '段階ログに [scan:font-input] ok がない',
-      ).toBe(true);
-      const scanErrors = logs.filter((l) => l.type === 'error' && l.text.startsWith('[scan:'));
-      expect(scanErrors, '成功パスなのに [scan:*] エラーログがある').toEqual([]);
+        // 段階診断ログ（#109）: golden path 成功時は最終段階 font-input まで ok で到達し、
+        // 途中段階のエラーログ（[scan:*] の console.error）が1件も出ていないこと。
+        // withStageLogs の fn 内で検証することで、この検証だけが失敗した場合も
+        // scan-stage-logs 添付が付く
+        expect(
+          logs.some((l) => l.text.startsWith('[scan:font-input] ok')),
+          '段階ログに [scan:font-input] ok がない',
+        ).toBe(true);
+        const scanErrors = logs.filter((l) => l.type === 'error' && l.text.startsWith('[scan:'));
+        expect(scanErrors, '成功パスなのに [scan:*] エラーログがある').toEqual([]);
+      });
     } finally {
       // テスト用ZIPを削除
       if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);

--- a/tests/e2e/full-flow.spec.ts
+++ b/tests/e2e/full-flow.spec.ts
@@ -69,7 +69,7 @@ test.describe('フルフロー: テンプレート→スキャン→フォント
     await createZipFromFiles(files, zipPath);
 
     try {
-      await withStageLogs(page, testInfo, async () => {
+      const { logs } = await withStageLogs(page, testInfo, async () => {
         const fontPath = await runScanToFontFlow(page, zipPath);
 
         // TTFファイルサイズ確認
@@ -81,6 +81,15 @@ test.describe('フルフロー: テンプレート→スキャン→フォント
         const font = loadFont(fontPath);
         expectGlyphsForChars(font, HIRAGANA);
       });
+
+      // 段階診断ログ（#109）: golden path 成功時は最終段階 font-input まで ok で到達し、
+      // 途中段階のエラーログ（[scan:*] の console.error）が1件も出ていないこと
+      expect(
+        logs.some((l) => l.text.startsWith('[scan:font-input] ok')),
+        '段階ログに [scan:font-input] ok がない',
+      ).toBe(true);
+      const scanErrors = logs.filter((l) => l.type === 'error' && l.text.startsWith('[scan:'));
+      expect(scanErrors, '成功パスなのに [scan:*] エラーログがある').toEqual([]);
     } finally {
       // テスト用ZIPを削除
       if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);

--- a/tests/fixtures/distort.ts
+++ b/tests/fixtures/distort.ts
@@ -1,0 +1,280 @@
+/**
+ * 合成スキャン画像の擬似歪み生成（#109）
+ *
+ * 正面の模擬スキャン画像に「斜め撮影風」の歪みを加える。
+ * cli/src/distort.rs と同系統のパラメータ（回転 + 台形 + グレー背景 + 余白）を
+ * TypeScript / node-canvas 上で再現する。
+ *
+ * node-canvas の 2D コンテキストは射影変換をサポートしないため、
+ * 4隅対応点からホモグラフィ（8自由度）を解き、
+ * 出力→入力の逆写像 + バイリニア補間で自前実装する。
+ */
+
+import { createCanvas, loadImage } from 'canvas';
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface DistortOptions {
+  /** 回転角度（度）。正で時計回り */
+  rotateDeg?: number;
+  /** 台形歪みの強さ（0.0=なし, 0.05=cli/src/distort.rs のデフォルト） */
+  trapezoid?: number;
+  /** 全体の縮小率（1.0=等倍） */
+  scale?: number;
+  /** 余白（px）。グレー背景で埋める */
+  padding?: number;
+  /** 背景色（机/床のシミュレート） */
+  background?: [number, number, number];
+  /** 明度ムラ: 上端→下端の輝度倍率の振れ幅（例 0.12 → 上 1.06倍〜下 0.94倍） */
+  brightnessGradient?: number;
+  /** 3x3 ボックスぼかしを適用するか（軽いピンボケのシミュレート） */
+  blur?: boolean;
+}
+
+/**
+ * 4点対応 (src[i] → dst[i]) からホモグラフィ行列（3x3、h33=1 固定）を解く。
+ * 戻り値は行優先 [h11..h33] の 9 要素。
+ */
+export function computeHomography(src: Point[], dst: Point[]): number[] {
+  if (src.length !== 4 || dst.length !== 4) {
+    throw new Error('computeHomography: 4点対応が必要です');
+  }
+  // 8x8 線形系 A·h = b（h = [h11,h12,h13,h21,h22,h23,h31,h32]）
+  const A: number[][] = [];
+  const b: number[] = [];
+  for (let i = 0; i < 4; i++) {
+    const { x, y } = src[i];
+    const { x: u, y: v } = dst[i];
+    A.push([x, y, 1, 0, 0, 0, -u * x, -u * y]);
+    b.push(u);
+    A.push([0, 0, 0, x, y, 1, -v * x, -v * y]);
+    b.push(v);
+  }
+  const h = solveLinearSystem(A, b);
+  return [...h, 1];
+}
+
+/** ガウスの消去法（部分ピボット選択）で n×n 線形系を解く */
+function solveLinearSystem(A: number[][], b: number[]): number[] {
+  const n = b.length;
+  // 拡大係数行列
+  const m = A.map((row, i) => [...row, b[i]]);
+  for (let col = 0; col < n; col++) {
+    // ピボット選択
+    let pivot = col;
+    for (let row = col + 1; row < n; row++) {
+      if (Math.abs(m[row][col]) > Math.abs(m[pivot][col])) pivot = row;
+    }
+    if (Math.abs(m[pivot][col]) < 1e-12) {
+      throw new Error('solveLinearSystem: 特異行列（対応点が退化しています）');
+    }
+    [m[col], m[pivot]] = [m[pivot], m[col]];
+    // 前進消去
+    for (let row = col + 1; row < n; row++) {
+      const f = m[row][col] / m[col][col];
+      for (let k = col; k <= n; k++) m[row][k] -= f * m[col][k];
+    }
+  }
+  // 後退代入
+  const x = new Array<number>(n).fill(0);
+  for (let row = n - 1; row >= 0; row--) {
+    let sum = m[row][n];
+    for (let k = row + 1; k < n; k++) sum -= m[row][k] * x[k];
+    x[row] = sum / m[row][row];
+  }
+  return x;
+}
+
+/** ホモグラフィ行列を点に適用する */
+export function applyHomography(h: number[], x: number, y: number): Point {
+  const w = h[6] * x + h[7] * y + h[8];
+  return {
+    x: (h[0] * x + h[1] * y + h[2]) / w,
+    y: (h[3] * x + h[4] * y + h[5]) / w,
+  };
+}
+
+/**
+ * 出力キャンバス上での元画像4隅の配置座標を計算する。
+ * cli/src/distort.rs と同じ手順: 中心基準 → 縮小 → 回転 → 台形 → 中心オフセット。
+ * 順序は [TL, TR, BL, BR]。
+ */
+export function computeDistortedCorners(
+  srcW: number,
+  srcH: number,
+  outW: number,
+  outH: number,
+  opts: DistortOptions,
+): Point[] {
+  const rotateDeg = opts.rotateDeg ?? 0;
+  const t = opts.trapezoid ?? 0;
+  const scale = opts.scale ?? 1;
+
+  const halfW = (srcW / 2) * scale;
+  const halfH = (srcH / 2) * scale;
+  const cx = outW / 2;
+  const cy = outH / 2;
+
+  const rad = (rotateDeg * Math.PI) / 180;
+  const cosR = Math.cos(rad);
+  const sinR = Math.sin(rad);
+
+  const local: Point[] = [
+    { x: -halfW, y: -halfH }, // TL
+    { x: halfW, y: -halfH }, // TR
+    { x: -halfW, y: halfH }, // BL
+    { x: halfW, y: halfH }, // BR
+  ];
+
+  const rotated = local.map(({ x, y }) => ({
+    x: x * cosR - y * sinR,
+    y: x * sinR + y * cosR,
+  }));
+
+  // 台形変形: 上辺を狭く、下辺を広く（distort.rs と同じ係数）
+  const trapezoided: Point[] = [
+    { x: rotated[0].x + halfW * t, y: rotated[0].y - halfH * t * 0.3 },
+    { x: rotated[1].x - halfW * t, y: rotated[1].y - halfH * t * 0.3 },
+    { x: rotated[2].x - halfW * t * 0.5, y: rotated[2].y + halfH * t * 0.2 },
+    { x: rotated[3].x + halfW * t * 0.5, y: rotated[3].y + halfH * t * 0.2 },
+  ];
+
+  return trapezoided.map(({ x, y }) => ({ x: cx + x, y: cy + y }));
+}
+
+/**
+ * PNG バッファに擬似歪みを適用して PNG バッファを返す。
+ * 出力サイズは 入力サイズ + 余白×2。
+ */
+export async function distortPng(input: Buffer, opts: DistortOptions): Promise<Buffer> {
+  const img = await loadImage(input);
+  const srcW = img.width;
+  const srcH = img.height;
+  const padding = opts.padding ?? 200;
+  const background = opts.background ?? [200, 195, 185];
+  const outW = srcW + padding * 2;
+  const outH = srcH + padding * 2;
+
+  // 元画像のピクセルを取得
+  const srcCanvas = createCanvas(srcW, srcH);
+  const srcCtx = srcCanvas.getContext('2d');
+  srcCtx.drawImage(img, 0, 0);
+  const src = srcCtx.getImageData(0, 0, srcW, srcH).data;
+
+  // 出力4隅 → 元画像4隅 の逆方向ホモグラフィを解く
+  const dstCorners = computeDistortedCorners(srcW, srcH, outW, outH, opts);
+  const srcCorners: Point[] = [
+    { x: 0, y: 0 },
+    { x: srcW - 1, y: 0 },
+    { x: 0, y: srcH - 1 },
+    { x: srcW - 1, y: srcH - 1 },
+  ];
+  const hInv = computeHomography(dstCorners, srcCorners);
+
+  const outCanvas = createCanvas(outW, outH);
+  const outCtx = outCanvas.getContext('2d');
+  const outImage = outCtx.createImageData(outW, outH);
+  const out = outImage.data;
+
+  const grad = opts.brightnessGradient ?? 0;
+  const [bgR, bgG, bgB] = background;
+
+  for (let dy = 0; dy < outH; dy++) {
+    // 明度ムラ: 上端 1+grad/2 → 下端 1-grad/2 の線形勾配
+    const brightness = grad === 0 ? 1 : 1 + grad * (0.5 - dy / (outH - 1));
+    for (let dx = 0; dx < outW; dx++) {
+      const o = (dy * outW + dx) * 4;
+      const { x: sx, y: sy } = applyHomography(hInv, dx, dy);
+
+      let r = bgR;
+      let g = bgG;
+      let b = bgB;
+      if (sx >= 0 && sx <= srcW - 1 && sy >= 0 && sy <= srcH - 1) {
+        // バイリニア補間
+        const x0 = Math.floor(sx);
+        const y0 = Math.floor(sy);
+        const x1 = Math.min(x0 + 1, srcW - 1);
+        const y1 = Math.min(y0 + 1, srcH - 1);
+        const fx = sx - x0;
+        const fy = sy - y0;
+        const i00 = (y0 * srcW + x0) * 4;
+        const i10 = (y0 * srcW + x1) * 4;
+        const i01 = (y1 * srcW + x0) * 4;
+        const i11 = (y1 * srcW + x1) * 4;
+        const w00 = (1 - fx) * (1 - fy);
+        const w10 = fx * (1 - fy);
+        const w01 = (1 - fx) * fy;
+        const w11 = fx * fy;
+        r = src[i00] * w00 + src[i10] * w10 + src[i01] * w01 + src[i11] * w11;
+        g = src[i00 + 1] * w00 + src[i10 + 1] * w10 + src[i01 + 1] * w01 + src[i11 + 1] * w11;
+        b = src[i00 + 2] * w00 + src[i10 + 2] * w10 + src[i01 + 2] * w01 + src[i11 + 2] * w11;
+      }
+
+      out[o] = clamp255(r * brightness);
+      out[o + 1] = clamp255(g * brightness);
+      out[o + 2] = clamp255(b * brightness);
+      out[o + 3] = 255;
+    }
+  }
+
+  if (opts.blur) {
+    boxBlur3x3(out, outW, outH);
+  }
+
+  outCtx.putImageData(outImage, 0, 0);
+  return outCanvas.toBuffer('image/png');
+}
+
+function clamp255(v: number): number {
+  return v < 0 ? 0 : v > 255 ? 255 : Math.round(v);
+}
+
+/** 3x3 ボックスぼかし（RGBのみ、in-place） */
+function boxBlur3x3(data: Uint8ClampedArray, w: number, h: number): void {
+  const srcCopy = new Uint8ClampedArray(data);
+  for (let y = 1; y < h - 1; y++) {
+    for (let x = 1; x < w - 1; x++) {
+      for (let c = 0; c < 3; c++) {
+        let sum = 0;
+        for (let ky = -1; ky <= 1; ky++) {
+          for (let kx = -1; kx <= 1; kx++) {
+            sum += srcCopy[((y + ky) * w + (x + kx)) * 4 + c];
+          }
+        }
+        data[(y * w + x) * 4 + c] = Math.round(sum / 9);
+      }
+    }
+  }
+}
+
+/**
+ * 歪みバリアント定義。generate-mock-scans.ts と e2e の両方から参照する
+ * （ファイル名 suffix とパラメータの二重管理を避ける）。
+ */
+export const DISTORT_VARIANTS: { suffix: string; opts: DistortOptions }[] = [
+  {
+    // 台形変形（cli/src/distort.rs のデフォルトと同強度）
+    suffix: 'perspective',
+    opts: { trapezoid: 0.05, padding: 200 },
+  },
+  {
+    // 数度の回転
+    suffix: 'rotated',
+    opts: { rotateDeg: 3, padding: 200 },
+  },
+  {
+    // 複合: 軽い回転 + 軽い台形 + 縮小 + 明度ムラ + 軽いぼかし
+    suffix: 'combined',
+    opts: {
+      rotateDeg: 2,
+      trapezoid: 0.03,
+      scale: 0.92,
+      padding: 200,
+      brightnessGradient: 0.1,
+      blur: true,
+    },
+  },
+];

--- a/tests/fixtures/generate-mock-scans.ts
+++ b/tests/fixtures/generate-mock-scans.ts
@@ -232,8 +232,22 @@ async function generatePage(pageIdx: number, chars: string[]): Promise<Buffer> {
   return canvas.toBuffer('image/png');
 }
 
-export async function generateMockScans(outputDir: string): Promise<string[]> {
+/**
+ * 出力ディレクトリを用意し、既存の PNG を削除する。
+ * ページ数や歪みバリアントが減った時に前回生成の stale なフィクスチャが
+ * 残留して e2e に混入するのを防ぐ（ZIP 化は「ディレクトリ内の全 PNG」で拾うため）。
+ */
+function prepareOutputDir(outputDir: string): void {
   fs.mkdirSync(outputDir, { recursive: true });
+  for (const entry of fs.readdirSync(outputDir)) {
+    if (entry.endsWith('.png')) {
+      fs.unlinkSync(path.join(outputDir, entry));
+    }
+  }
+}
+
+export async function generateMockScans(outputDir: string): Promise<string[]> {
+  prepareOutputDir(outputDir);
 
   const totalPages = Math.ceil(HIRAGANA.length / CHARS_PER_PAGE);
   const files: string[] = [];
@@ -264,7 +278,7 @@ export async function generateDistortedScans(
   frontalFiles: string[],
   outputDir: string,
 ): Promise<string[]> {
-  fs.mkdirSync(outputDir, { recursive: true });
+  prepareOutputDir(outputDir);
   const files: string[] = [];
 
   for (const frontalPath of frontalFiles) {
@@ -295,5 +309,11 @@ if (
     .then((files) => generateDistortedScans(files, distortedDir).then((d) => [...files, ...d]))
     .then((files) => {
       console.log(`\nDone! Generated ${files.length} mock scan images.`);
+    })
+    .catch((e) => {
+      // 失敗を握りつぶすと test:e2e が古いフィクスチャのまま走ってしまうため、
+      // 原因を出力して非0で終了する
+      console.error('mock scan generation failed:', e);
+      process.exitCode = 1;
     });
 }

--- a/tests/fixtures/generate-mock-scans.ts
+++ b/tests/fixtures/generate-mock-scans.ts
@@ -5,7 +5,10 @@
  * 各マスの内枠にフォントで文字を描画する。
  * QRコード・四隅マーカー・シアン要素も含める。
  *
- * 出力: tests/fixtures/mock-scans/ に PNG ファイル
+ * 出力:
+ * - tests/fixtures/mock-scans/ に正面 PNG（page-NN.png）
+ * - tests/fixtures/mock-scans-distorted/ に斜め撮影風バリアント
+ *   （page-NN-perspective.png / page-NN-rotated.png / page-NN-combined.png、#109）
  */
 
 import { createCanvas } from 'canvas';
@@ -47,95 +50,10 @@ import {
   gridToCharIndex,
 } from '../../src/lib/template/layout';
 
-// ひらがな（characters.ts と同じ順序）
-const HIRAGANA = [
-  'あ',
-  'い',
-  'う',
-  'え',
-  'お',
-  'か',
-  'き',
-  'く',
-  'け',
-  'こ',
-  'さ',
-  'し',
-  'す',
-  'せ',
-  'そ',
-  'た',
-  'ち',
-  'つ',
-  'て',
-  'と',
-  'な',
-  'に',
-  'ぬ',
-  'ね',
-  'の',
-  'は',
-  'ひ',
-  'ふ',
-  'へ',
-  'ほ',
-  'ま',
-  'み',
-  'む',
-  'め',
-  'も',
-  'や',
-  'ゆ',
-  'よ',
-  'ら',
-  'り',
-  'る',
-  'れ',
-  'ろ',
-  'わ',
-  'を',
-  'ん',
-  'が',
-  'ぎ',
-  'ぐ',
-  'げ',
-  'ご',
-  'ざ',
-  'じ',
-  'ず',
-  'ぜ',
-  'ぞ',
-  'だ',
-  'ぢ',
-  'づ',
-  'で',
-  'ど',
-  'ば',
-  'び',
-  'ぶ',
-  'べ',
-  'ぼ',
-  'ぱ',
-  'ぴ',
-  'ぷ',
-  'ぺ',
-  'ぽ',
-  'ぁ',
-  'ぃ',
-  'ぅ',
-  'ぇ',
-  'ぉ',
-  'っ',
-  'ゃ',
-  'ゅ',
-  'ょ',
-  'ゎ',
-  'ゐ',
-  'ゑ',
-];
-
-import { CHARS_PER_PAGE } from '../../src/data/characters';
+// ひらがな83文字はテンプレート生成と同じ正本（characters.ts）から取得する（二重管理禁止）
+import { HIRAGANA, CHARS_PER_PAGE } from '../../src/data/characters';
 import { getCellPosition } from '../../src/lib/template/layout';
+import { distortPng, DISTORT_VARIANTS } from './distort';
 
 // 解像度: 300dpi 相当（mm→pixel 変換）
 const DPI = 300;
@@ -337,13 +255,45 @@ export async function generateMockScans(outputDir: string): Promise<string[]> {
   return files;
 }
 
+/**
+ * 正面画像から斜め撮影風の歪みバリアントを生成する（#109）。
+ * 出力先を分けているのは、既存の正面 e2e（mock-scans/ 全 PNG を ZIP 化）に
+ * 歪み画像が混入しないようにするため。
+ */
+export async function generateDistortedScans(
+  frontalFiles: string[],
+  outputDir: string,
+): Promise<string[]> {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const files: string[] = [];
+
+  for (const frontalPath of frontalFiles) {
+    const input = fs.readFileSync(frontalPath);
+    const base = path.basename(frontalPath, '.png'); // page-NN
+    for (const { suffix, opts } of DISTORT_VARIANTS) {
+      const buffer = await distortPng(input, opts);
+      const filename = `${base}-${suffix}.png`;
+      const filepath = path.join(outputDir, filename);
+      fs.writeFileSync(filepath, buffer);
+      files.push(filepath);
+      console.log(`Generated: ${filename}`);
+    }
+  }
+
+  return files;
+}
+
 // CLI から直接実行された場合
 if (
   process.argv[1]?.endsWith('generate-mock-scans.ts') ||
   process.argv[1]?.endsWith('generate-mock-scans.js')
 ) {
-  const outDir = path.join(import.meta.dirname ?? path.dirname(process.argv[1]), 'mock-scans');
-  generateMockScans(outDir).then((files) => {
-    console.log(`\nDone! Generated ${files.length} mock scan images.`);
-  });
+  const fixturesDir = import.meta.dirname ?? path.dirname(process.argv[1]);
+  const outDir = path.join(fixturesDir, 'mock-scans');
+  const distortedDir = path.join(fixturesDir, 'mock-scans-distorted');
+  generateMockScans(outDir)
+    .then((files) => generateDistortedScans(files, distortedDir).then((d) => [...files, ...d]))
+    .then((files) => {
+      console.log(`\nDone! Generated ${files.length} mock scan images.`);
+    });
 }

--- a/tests/unit/distort.test.ts
+++ b/tests/unit/distort.test.ts
@@ -1,0 +1,370 @@
+/**
+ * tests/fixtures/distort.ts（擬似歪み生成、#109）のユニットテスト。
+ *
+ * - computeHomography / applyHomography: 解析解との厳密比較・異常系
+ * - computeDistortedCorners: 回転・台形の座標計算
+ * - distortPng: 余白・背景・バイリニア境界・明度ムラ・ぼかしの実画素検証
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createCanvas, loadImage } from 'canvas';
+import {
+  computeHomography,
+  applyHomography,
+  computeDistortedCorners,
+  distortPng,
+  type Point,
+} from '../fixtures/distort';
+
+// --- テスト用ヘルパー ---
+
+/** (x,y) ごとに RGB を指定して PNG バッファを作る */
+function makePng(
+  w: number,
+  h: number,
+  fill: (x: number, y: number) => [number, number, number],
+): Buffer {
+  const canvas = createCanvas(w, h);
+  const ctx = canvas.getContext('2d');
+  const img = ctx.createImageData(w, h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const [r, g, b] = fill(x, y);
+      const i = (y * w + x) * 4;
+      img.data[i] = r;
+      img.data[i + 1] = g;
+      img.data[i + 2] = b;
+      img.data[i + 3] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+  return canvas.toBuffer('image/png');
+}
+
+interface Pixels {
+  w: number;
+  h: number;
+  data: Uint8ClampedArray;
+}
+
+/** PNG バッファをデコードして RGBA 配列を返す */
+async function readPixels(buf: Buffer): Promise<Pixels> {
+  const img = await loadImage(buf);
+  const canvas = createCanvas(img.width, img.height);
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  return {
+    w: img.width,
+    h: img.height,
+    data: ctx.getImageData(0, 0, img.width, img.height).data,
+  };
+}
+
+/** (x,y) の RGB を取り出す */
+function rgbAt(p: Pixels, x: number, y: number): [number, number, number] {
+  const i = (y * p.w + x) * 4;
+  return [p.data[i], p.data[i + 1], p.data[i + 2]];
+}
+
+describe('computeHomography / applyHomography', () => {
+  it('恒等対応（src = dst）では単位行列を返す', () => {
+    // 正方形でない一般の4点で恒等対応を解く
+    const corners: Point[] = [
+      { x: 10, y: 20 },
+      { x: 110, y: 25 },
+      { x: 15, y: 120 },
+      { x: 105, y: 115 },
+    ];
+    const h = computeHomography(corners, corners);
+    const identity = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+    for (let i = 0; i < 9; i++) {
+      expect(Math.abs(h[i] - identity[i])).toBeLessThan(1e-9);
+    }
+  });
+
+  it('単位正方形→2倍+平行移動の対応で内部点が解析解どおりに写る', () => {
+    // (x,y) → (2x+3, 2y+5)。ホモグラフィは h = [2,0,3, 0,2,5, 0,0,1]
+    const src: Point[] = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ];
+    const dst: Point[] = [
+      { x: 3, y: 5 },
+      { x: 5, y: 5 },
+      { x: 3, y: 7 },
+      { x: 5, y: 7 },
+    ];
+    const h = computeHomography(src, dst);
+    const expected = [2, 0, 3, 0, 2, 5, 0, 0, 1];
+    for (let i = 0; i < 9; i++) {
+      expect(Math.abs(h[i] - expected[i])).toBeLessThan(1e-12);
+    }
+    // 対応点として与えていない内部点・外部点の写像先も解析解と一致する
+    const center = applyHomography(h, 0.5, 0.5);
+    expect(Math.abs(center.x - 4)).toBeLessThan(1e-12);
+    expect(Math.abs(center.y - 6)).toBeLessThan(1e-12);
+    const outer = applyHomography(h, 2, 3);
+    expect(Math.abs(outer.x - 7)).toBeLessThan(1e-12);
+    expect(Math.abs(outer.y - 11)).toBeLessThan(1e-12);
+  });
+
+  it('順方向と逆方向を独立に解いた往復写像が元の点に戻る（射影成分あり）', () => {
+    // 台形対応（h31/h32 が非ゼロになる真の射影変換）
+    const src: Point[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 0, y: 100 },
+      { x: 100, y: 100 },
+    ];
+    const dst: Point[] = [
+      { x: 15, y: 5 },
+      { x: 85, y: 8 },
+      { x: 2, y: 95 },
+      { x: 98, y: 92 },
+    ];
+    const h = computeHomography(src, dst);
+    const hInv = computeHomography(dst, src);
+    const probes: Point[] = [
+      { x: 50, y: 50 },
+      { x: 10, y: 90 },
+      { x: 99, y: 1 },
+      { x: 33.3, y: 66.7 },
+    ];
+    for (const p of probes) {
+      const there = applyHomography(h, p.x, p.y);
+      const back = applyHomography(hInv, there.x, there.y);
+      expect(Math.abs(back.x - p.x)).toBeLessThan(1e-6);
+      expect(Math.abs(back.y - p.y)).toBeLessThan(1e-6);
+    }
+  });
+
+  it('対応点が4点でないと throw する', () => {
+    const three: Point[] = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+    ];
+    const four: Point[] = [...three, { x: 1, y: 1 }];
+    const five: Point[] = [...four, { x: 2, y: 2 }];
+    expect(() => computeHomography(three, four)).toThrow('4点対応が必要です');
+    expect(() => computeHomography(four, three)).toThrow('4点対応が必要です');
+    expect(() => computeHomography(five, five)).toThrow('4点対応が必要です');
+  });
+
+  it('退化した対応点（同一点・一直線）では特異行列として throw する', () => {
+    const square: Point[] = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ];
+    // 3点が同一
+    const collapsed: Point[] = [
+      { x: 5, y: 5 },
+      { x: 5, y: 5 },
+      { x: 5, y: 5 },
+      { x: 1, y: 1 },
+    ];
+    expect(() => computeHomography(collapsed, square)).toThrow('特異行列');
+    // 全点が一直線
+    const collinear: Point[] = [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+      { x: 2, y: 2 },
+      { x: 3, y: 3 },
+    ];
+    expect(() => computeHomography(collinear, square)).toThrow('特異行列');
+  });
+});
+
+describe('computeDistortedCorners', () => {
+  it('デフォルト（無回転・無台形・等倍）では出力中心の軸平行矩形になる', () => {
+    // src 100x80, out 140x120 → 中心 (70,60)、半幅 50、半高 40
+    const corners = computeDistortedCorners(100, 80, 140, 120, {});
+    expect(corners).toEqual([
+      { x: 20, y: 20 }, // TL
+      { x: 120, y: 20 }, // TR
+      { x: 20, y: 100 }, // BL
+      { x: 120, y: 100 }, // BR
+    ]);
+  });
+
+  it('rotateDeg=90 で4隅が解析解（TL→右上へ90度回転）と一致する', () => {
+    // halfW=50, halfH=40, 中心 (70,60)。時計回り90度: (x,y) → (-y, x)
+    // TL(-50,-40) → (40,-50), TR(50,-40) → (40,50), BL(-50,40) → (-40,-50), BR(50,40) → (-40,50)
+    const corners = computeDistortedCorners(100, 80, 140, 120, { rotateDeg: 90 });
+    const expected: Point[] = [
+      { x: 110, y: 10 }, // TL
+      { x: 110, y: 110 }, // TR
+      { x: 30, y: 10 }, // BL
+      { x: 30, y: 110 }, // BR
+    ];
+    for (let i = 0; i < 4; i++) {
+      // cos(90°) は浮動小数点上ゼロにならない（≈6e-17）ため閾値比較
+      expect(Math.abs(corners[i].x - expected[i].x)).toBeLessThan(1e-10);
+      expect(Math.abs(corners[i].y - expected[i].y)).toBeLessThan(1e-10);
+    }
+  });
+
+  it('trapezoid の符号と強度で上辺の狭まり方が変わる（0 / 0.05 / -0.05）', () => {
+    const base = computeDistortedCorners(100, 80, 140, 120, { trapezoid: 0 });
+    // t=0 は無変形（デフォルト矩形と同一）
+    expect(base).toEqual([
+      { x: 20, y: 20 },
+      { x: 120, y: 20 },
+      { x: 20, y: 100 },
+      { x: 120, y: 100 },
+    ]);
+
+    // t=0.05: 上辺が狭くなる（TL.x は +halfW*t、TR.x は -halfW*t）
+    const t = computeDistortedCorners(100, 80, 140, 120, { trapezoid: 0.05 });
+    expect(t[0].x).toBeCloseTo(20 + 50 * 0.05, 12); // TL: 22.5
+    expect(t[1].x).toBeCloseTo(120 - 50 * 0.05, 12); // TR: 117.5
+    expect(t[0].y).toBeCloseTo(20 - 40 * 0.05 * 0.3, 12); // TL.y: 19.4
+    expect(t[2].x).toBeCloseTo(20 - 50 * 0.05 * 0.5, 12); // BL: 18.75
+    expect(t[2].y).toBeCloseTo(100 + 40 * 0.05 * 0.2, 12); // BL.y: 100.4
+
+    // t=-0.05: 逆台形（上辺が広くなる）
+    const n = computeDistortedCorners(100, 80, 140, 120, { trapezoid: -0.05 });
+    expect(n[0].x).toBeCloseTo(20 - 50 * 0.05, 12); // TL: 17.5
+    expect(n[1].x).toBeCloseTo(120 + 50 * 0.05, 12); // TR: 122.5
+  });
+});
+
+describe('distortPng', () => {
+  it('歪み無し + padding:0 では出力サイズ・全ピクセルが入力と一致する', async () => {
+    // バイリニア再標本化は (W-1)/W のスケールを含むため、非一様画像では
+    // 補間により厳密一致しない（実装仕様）。一様色なら補間結果も同色になるので
+    // 「背景の混入なし・明度変化なし・値の劣化なし」を厳密に検証できる。
+    const input = makePng(4, 4, () => [90, 120, 150]);
+    const out = await readPixels(await distortPng(input, { padding: 0 }));
+    expect(out.w).toBe(4);
+    expect(out.h).toBe(4);
+    for (let y = 0; y < out.h; y++) {
+      for (let x = 0; x < out.w; x++) {
+        expect(rgbAt(out, x, y), `(${x},${y})`).toEqual([90, 120, 150]);
+      }
+    }
+  });
+
+  it('バイリニア境界: 画像端 sx=srcW-1 は「内側」扱いになる（<= と < の差を検出）', async () => {
+    // 白 4x4 + padding:1 + 青背景 → 出力 6x6。
+    // 出力 (dx,dy) は src ((dx-1)*3/4, (dy-1)*3/4) に写る:
+    // - dx=0 / dy=0 → 負 → 背景
+    // - dx=5 / dy=5 → ちょうど srcW-1=3 → 判定が `<=` なので画像内（白）。
+    //   実装が `<` に変わるとこの行・列が背景になり、このテストが落ちる。
+    // - dx=1 / dy=1 は写像先がちょうど 0 で、ガウス消去の丸めにより ±ε に
+    //   振れうるナイフエッジのため、意図的に検証対象から外す。
+    const input = makePng(4, 4, () => [255, 255, 255]);
+    const out = await readPixels(await distortPng(input, { padding: 1, background: [0, 0, 255] }));
+    expect(out.w).toBe(6);
+    expect(out.h).toBe(6);
+    const BG: [number, number, number] = [0, 0, 255];
+    const WHITE: [number, number, number] = [255, 255, 255];
+    // 上端行・左端列（写像先が確実に負）は背景
+    for (let i = 0; i < 6; i++) {
+      expect(rgbAt(out, i, 0), `top (${i},0)`).toEqual(BG);
+      expect(rgbAt(out, 0, i), `left (0,${i})`).toEqual(BG);
+    }
+    // 右端列 dx=5（sx=3=srcW-1）・下端行 dy=5（sy=3=srcH-1）は画像内=白
+    for (let i = 2; i <= 5; i++) {
+      expect(rgbAt(out, 5, i), `right (5,${i})`).toEqual(WHITE);
+      expect(rgbAt(out, i, 5), `bottom (${i},5)`).toEqual(WHITE);
+    }
+    // 内部は白
+    for (let y = 2; y <= 4; y++) {
+      for (let x = 2; x <= 4; x++) {
+        expect(rgbAt(out, x, y), `inner (${x},${y})`).toEqual(WHITE);
+      }
+    }
+  });
+
+  it('padding:200 では出力が入力+400になり四隅は背景色で埋まる', async () => {
+    const bg: [number, number, number] = [10, 20, 30];
+    const input = makePng(8, 8, () => [255, 0, 0]);
+    const out = await readPixels(await distortPng(input, { padding: 200, background: bg }));
+    expect(out.w).toBe(8 + 400);
+    expect(out.h).toBe(8 + 400);
+    expect(rgbAt(out, 0, 0)).toEqual(bg);
+    expect(rgbAt(out, out.w - 1, 0)).toEqual(bg);
+    expect(rgbAt(out, 0, out.h - 1)).toEqual(bg);
+    expect(rgbAt(out, out.w - 1, out.h - 1)).toEqual(bg);
+  });
+
+  it('brightnessGradient で上端が明るく下端が暗くなり、白はクランプで255のまま', async () => {
+    // 一様グレー128: 上端 128*1.05=134、下端 128*0.95≈122
+    const gray = makePng(4, 8, () => [128, 128, 128]);
+    const outGray = await readPixels(
+      await distortPng(gray, { padding: 0, brightnessGradient: 0.1 }),
+    );
+    const [topR] = rgbAt(outGray, 0, 0);
+    const [bottomR] = rgbAt(outGray, 0, outGray.h - 1);
+    expect(topR).toBe(134);
+    expect(bottomR).toBe(122);
+    expect(topR).toBeGreaterThan(bottomR);
+
+    // 純白 255 は上端の増幅（×1.05）でもクランプされ 255 のまま
+    const white = makePng(4, 8, () => [255, 255, 255]);
+    const outWhite = await readPixels(
+      await distortPng(white, { padding: 0, brightnessGradient: 0.1 }),
+    );
+    expect(rgbAt(outWhite, 0, 0)).toEqual([255, 255, 255]);
+  });
+
+  it('blur は内部を3x3平均化し、最外周1行1列には触れない', async () => {
+    // 白地の (0,0) に黒1px。blur 有無で同条件の出力を比較する:
+    // - 最外周（y=0, y=h-1, x=0, x=w-1）は blur 前後で完全一致
+    //   （ループが 1..h-2 / 1..w-2 なので端は書き換えない。0..h-1 に変わると落ちる）
+    // - 内部の各ピクセルは「blur 無し出力の3x3平均（round）」と一致
+    const input = makePng(6, 6, (x, y) => (x === 0 && y === 0 ? [0, 0, 0] : [255, 255, 255]));
+    const plain = await readPixels(await distortPng(input, { padding: 0 }));
+    const blurred = await readPixels(await distortPng(input, { padding: 0, blur: true }));
+    expect(blurred.w).toBe(plain.w);
+    expect(blurred.h).toBe(plain.h);
+
+    // 最外周は不変
+    for (let x = 0; x < plain.w; x++) {
+      expect(rgbAt(blurred, x, 0), `top (${x},0)`).toEqual(rgbAt(plain, x, 0));
+      expect(rgbAt(blurred, x, plain.h - 1), `bottom (${x},${plain.h - 1})`).toEqual(
+        rgbAt(plain, x, plain.h - 1),
+      );
+    }
+    for (let y = 0; y < plain.h; y++) {
+      expect(rgbAt(blurred, 0, y), `left (0,${y})`).toEqual(rgbAt(plain, 0, y));
+      expect(rgbAt(blurred, plain.w - 1, y), `right (${plain.w - 1},${y})`).toEqual(
+        rgbAt(plain, plain.w - 1, y),
+      );
+    }
+
+    // 内部 = 3x3 平均（blur 無し出力から期待値を計算）
+    for (let y = 1; y < plain.h - 1; y++) {
+      for (let x = 1; x < plain.w - 1; x++) {
+        for (let c = 0; c < 3; c++) {
+          let sum = 0;
+          for (let ky = -1; ky <= 1; ky++) {
+            for (let kx = -1; kx <= 1; kx++) {
+              sum += plain.data[((y + ky) * plain.w + (x + kx)) * 4 + c];
+            }
+          }
+          expect(blurred.data[(y * plain.w + x) * 4 + c], `(${x},${y}) ch${c}`).toBe(
+            Math.round(sum / 9),
+          );
+        }
+      }
+    }
+
+    // 黒1px の影響が実際に及ぶ (1,1) は blur で変化している（テストが空振りしていない証明）
+    expect(rgbAt(blurred, 1, 1)).not.toEqual(rgbAt(plain, 1, 1));
+  });
+
+  it('オプション空 {} でも throw せずデフォルト（padding:200・机色背景）で動く', async () => {
+    const input = makePng(4, 4, () => [0, 0, 0]);
+    const out = await readPixels(await distortPng(input, {}));
+    expect(out.w).toBe(4 + 400);
+    expect(out.h).toBe(4 + 400);
+    // デフォルト背景 [200,195,185]
+    expect(rgbAt(out, 0, 0)).toEqual([200, 195, 185]);
+  });
+});

--- a/tests/unit/processor.test.ts
+++ b/tests/unit/processor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { translateWasmError } from '../../src/lib/scanner/processor';
+import { inferFailedStage, translateWasmError } from '../../src/lib/scanner/processor';
 
 describe('translateWasmError', () => {
   it('マーカー検出失敗を撮影ガイド付きメッセージに変換する', () => {
@@ -38,5 +38,61 @@ describe('translateWasmError', () => {
     const raw = '画像デコードエラー: unsupported format';
     const result = translateWasmError(raw, null);
     expect(result).toBe(raw);
+  });
+});
+
+describe('inferFailedStage', () => {
+  // 代表文言は Rust 側の実メッセージ（cli/src/marker.rs / cli/src/pipeline.rs）をコピーしたもの。
+  // Rust 側の文言が変わったらここも追従する。
+
+  it('マーカー検出失敗の実文言を marker と判定する', () => {
+    // cli/src/marker.rs
+    const raw = 'TopLeft マーカーが検出できませんでした（ブロブ数=0, フィルタ通過=0）';
+    expect(inferFailedStage(raw)).toBe('marker');
+  });
+
+  it('解像度不足の実文言を dpi と判定する', () => {
+    // cli/src/pipeline.rs
+    const raw =
+      '解像度が低すぎます (147 DPI)。もう少し近づけて撮影してください（推奨: 300DPI以上）';
+    expect(inferFailedStage(raw)).toBe('dpi');
+  });
+
+  it('レンズ歪み過大の実文言を perspective と判定する', () => {
+    // cli/src/pipeline.rs（歪み + 撮り直し の両キーワードを含む）
+    const raw =
+      'レンズ歪みが大きすぎます（中心残差 3.5mm、許容 2.0mm以下）。もう一歩離れて撮り直してください。';
+    expect(inferFailedStage(raw)).toBe('perspective');
+  });
+
+  it('画像デコード/フォーマット失敗の実文言を decode と判定する', () => {
+    // cli/src/pipeline.rs
+    expect(inferFailedStage('画像デコードエラー: unsupported format')).toBe('decode');
+    expect(inferFailedStage('画像フォーマット推定エラー: unknown magic')).toBe('decode');
+  });
+
+  it('どの段階キーワードにも該当しない実文言は wasm にフォールバックする', () => {
+    // cli/src/pipeline.rs。「デコーダ」は「デコード」と部分一致しないため decode にならない
+    expect(inferFailedStage('デコーダ初期化エラー: out of memory')).toBe('wasm');
+    expect(inferFailedStage('unreachable executed')).toBe('wasm');
+  });
+
+  it('複数キーワード同時ヒット時は marker > dpi > perspective > decode の先勝ちが崩れない', () => {
+    // 注意（将来リスク）: 「マーカー」のマッチは意図的に最優先だが判定が広い。
+    // 将来 Rust 側の perspective/dpi 系メッセージが「マーカー」という語を含むように
+    // 変わると marker に誤分類される。文言変更時はこのテストで優先順位を再確認すること。
+    expect(inferFailedStage('歪み補正中にマーカー座標が不正でした')).toBe('marker');
+    expect(inferFailedStage('解像度不足でマーカーが検出できませんでした')).toBe('marker');
+    expect(inferFailedStage('解像度が低く歪み推定に失敗しました')).toBe('dpi');
+    expect(inferFailedStage('歪みが大きく画像のデコード結果を補正できません')).toBe('perspective');
+  });
+
+  it('decode 判定は「画像」と「デコード/フォーマット」の AND（片翼のみでは wasm）', () => {
+    expect(inferFailedStage('画像読み込みエラー: file not found')).toBe('wasm'); // 画像 のみ
+    expect(inferFailedStage('デコードに失敗しました')).toBe('wasm'); // デコード のみ
+  });
+
+  it('空文字は wasm にフォールバックする', () => {
+    expect(inferFailedStage('')).toBe('wasm');
   });
 });


### PR DESCRIPTION
## 関連 Issue

closes #109

## 変更内容

印刷・手書き・カメラ撮影なしで、スキャンパイプライン全段の成否を自動検証できる基盤を追加。

### 合成フィクスチャ
- `tests/fixtures/distort.ts` 新規: 4隅対応点からホモグラフィ（8x8ガウス消去）を解き、逆写像+バイリニア補間で射影変換。perspective（台形0.05）/ rotated（3°）/ combined（2°+台形0.03+縮小0.92+明度ムラ+ぼかし）の3バリアント
- `generate-mock-scans.ts`: ひらがな83字を `characters.ts` から導出（ハードコード二重管理を解消）、歪みバリアント出力、stale PNG 掃除、失敗時 exit code 非0

### 段階診断ログ
- `processor.ts` に `[scan:{stage}]` ログ（pipeline/marker/dpi/perspective/qr/chars/cells/vectorize/font-input）と `inferFailedStage` を追加。失敗時にどの段階で落ちたか console から特定できる。UI 挙動は不変

### e2e（2本 → 6本、18秒）
- 歪み3バリアントの golden path（perspective は2ページ83字全数）
- 期待値検証を「5文字サンプル」から**全83字**（glyph index > 0 かつ path 非空）に強化
- 失敗系: 白紙画像 → UI エラー表示 + `[scan:marker]` エラーログ（失敗段階特定の契約を常設検証）
- 共通処理を `font-flow-utils.ts` に集約、失敗時は段階ログをテスト出力に添付

### unit（50 → 72）
- distort: ホモグラフィ恒等/解析解/往復精度/退化点、バイリニア境界（`<=`↔`<` 狙撃）、明度ムラ・blur・既定値
- inferFailedStage: 5段階の同値分割 + キーワード優先順位のデシジョンテーブル

### docs
- `docs/image-processing.md` に合成フィクスチャ・歪みバリアント・段階ログの節を追加、`CLAUDE.md` のコマンド説明更新

## テスト

- `npm run check` ✅ / `npm run test` 72/72 ✅ / `npm run test:e2e` 6/6 ✅（メインコンテキストで実測）

## 発見した製品バグ（別 Issue）

- #115: マーカー欠落時に誤検出で補正が進み「QRが不鮮明」と誤診断される（本基盤の失敗系テスト作成中に発見）