### PR TITLE
BlobPart型エラー2件を修正しcheckにtsc --noEmitを追加 (#120)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\" \"*.md\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.md\"",
-    "check": "eslint src && prettier --check \"src/**/*.{ts,tsx,css}\" \"*.md\"",
+    "check": "tsc --noEmit && eslint src && prettier --check \"src/**/*.{ts,tsx,css}\" \"*.md\"",
     "test:e2e": "npm run test:generate-fixtures && playwright test",
     "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"

--- a/src/pages/Template.tsx
+++ b/src/pages/Template.tsx
@@ -55,7 +55,7 @@ export default function Template(props: Props) {
         includeKanji: includeKanji(),
         includeAlphaNum: includeAlphaNum(),
       });
-      const blob = new Blob([pdfBytes.buffer], { type: 'application/pdf' });
+      const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -232,7 +232,7 @@ export default function Upload(props: Props) {
 
     try {
       const pdfBytes = await generateRetryTemplatePDF(chars, props.fontName || 'MyHandwriting');
-      const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+      const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;


### PR DESCRIPTION
## 概要
`npx tsc --noEmit` が Template.tsx / Upload.tsx の BlobPart 型エラー2件で落ちていた。`npm run check` は eslint+prettier のみで型検査を含まずCIで露見しなかった。

Closes #120

## 変更
- **型エラー修正**: pdf-lib の `Uint8Array<ArrayBufferLike>`(SharedArrayBuffer分岐でBlobPart不適合)を `new Uint8Array(pdfBytes)` でArrayBuffer-backedにコピーして型を満たす。cast(as any/as BlobPart)不使用で型を正直に保つ
- **check強化**: `check` script に `tsc --noEmit` を前置し型退行を検知

## 検証
- `npx tsc --noEmit` 0エラー / `npm run check` 緑 / vitest 97 全緑