### PR TITLE
空パスのグリフをフォント登録からスキップしフォールバックを温存する (#117)

### DIFF
--- a/src/lib/font/builder.ts
+++ b/src/lib/font/builder.ts
@@ -52,6 +52,21 @@ export async function buildFont(opts: FontOptions): Promise<ArrayBuffer> {
   const glyphs: opentype.Glyph[] = [notdefGlyph, spaceGlyph];
 
   for (const vg of opts.glyphs) {
+    // 残渣のみで採用され品質ゲートでゼロ化されたセルは paths が空になる（#117）。
+    // 空アウトラインを uniXXXX として登録するとコードポイントを占有し、
+    // OS/ブラウザのフォントフォールバックを潰す（「その文字だけ表示されない」に見える）。
+    // そのため描画コマンドを持たないグリフは登録をスキップし、コードポイントを未割当のままにする。
+    if (isEffectivelyEmpty(vg.paths)) {
+      const uniLabel =
+        vg.unicode !== undefined
+          ? `U+${vg.unicode.toString(16).toUpperCase().padStart(4, '0')} "${String.fromCodePoint(vg.unicode)}"`
+          : vg.name;
+      console.warn(
+        `[buildFont] 空パスのグリフ ${uniLabel} (name=${vg.name}) をスキップ（フォールバック温存, #117）`,
+      );
+      continue;
+    }
+
     const path = convertToOpentypePath(vg.paths);
     const glyph = new opentype.Glyph({
       name: vg.name,
@@ -231,6 +246,22 @@ function convertFromOpentypePath(otPath: opentype.Path): PathCommand[][] {
   }
 
   return pathGroups;
+}
+
+/**
+ * paths が「実質的に空」かどうかを判定する（#117）。
+ * paths が空、または全サブパスが描画コマンド（moveTo/lineTo/curveTo = M/L/C）を
+ * 一切持たない（closePath = Z のみ、または空）場合に true。
+ * 実際に描かれる輪郭が無いグリフを検出する。
+ */
+export function isEffectivelyEmpty(pathGroups: PathCommand[][]): boolean {
+  if (pathGroups.length === 0) return true;
+  for (const commands of pathGroups) {
+    for (const cmd of commands) {
+      if (cmd.type === 'M' || cmd.type === 'L' || cmd.type === 'C') return false;
+    }
+  }
+  return true;
 }
 
 function convertToOpentypePath(pathGroups: PathCommand[][]): opentype.Path {

--- a/tests/unit/font-builder.test.ts
+++ b/tests/unit/font-builder.test.ts
@@ -179,6 +179,45 @@ describe('Font Builder', () => {
     }
   });
 
+  it('should skip empty-paths glyphs to preserve OS/browser fallback (#117)', async () => {
+    const glyphs: VectorGlyph[] = [
+      {
+        name: 'uni3042', // あ（正常な輪郭あり）
+        unicode: 0x3042,
+        advanceWidth: 1000,
+        paths: [
+          [
+            { type: 'M', x: 200, y: 200 },
+            { type: 'L', x: 800, y: 200 },
+            { type: 'L', x: 800, y: 700 },
+            { type: 'L', x: 200, y: 700 },
+            { type: 'Z', x: 0, y: 0 },
+          ],
+        ],
+      },
+      {
+        name: 'uni3044', // い（残渣がゼロ化され paths が空 = 描画コマンド無し）
+        unicode: 0x3044,
+        advanceWidth: 1000,
+        paths: [],
+      },
+    ];
+
+    const buffer = await buildFont({ familyName: 'FallbackFont', glyphs });
+    const font = opentype.parse(buffer);
+
+    // 正常グリフのコードポイントは存在する
+    const glyphA = font.charToGlyph('あ');
+    expect(glyphA.name).toBe('uni3042');
+    expect(font.charToGlyph('あ').index).not.toBe(0);
+
+    // 空グリフのコードポイントは未割当（.notdef=index 0 に落ちる）→ フォールバック温存
+    expect(font.charToGlyph('い').index).toBe(0);
+
+    // グリフ数: .notdef + space + あ のみ（い はスキップ）
+    expect(font.glyphs.length).toBe(3);
+  });
+
   it('should skip .notdef and space when importing', async () => {
     // 空のフォント（.notdef + space のみ）
     const buffer = await buildFont({


### PR DESCRIPTION
## 概要
残渣のみで採用され品質ゲートでゼロ化されたセルが、空アウトラインのまま uniXXXX としてフォント登録され、コードポイントを占有してOS/ブラウザのフォントフォールバックを潰していた（ユーザーには「その文字だけ表示されない」に見える）。

Closes #117

## 変更
- `buildFont` の登録ループで `isEffectivelyEmpty`(描画コマンドM/L/Cを一切持たない)判定を追加し、空グリフの登録をスキップ。コードポイントを未割当のまま残しフォールバックを効かせる
- `.notdef`/`space` はループ前に追加済みで影響なし（space の空パスは正当）

## 関連
- #112 で「採用セル×空パス→needs_review」を配線済み。本PRは**登録側の実害**（フォールバック潰し）を塞ぐ補完。review UIの見せ方は #114 スコープ

## 検証
- tsc 0エラー / vitest 98 全緑（新テスト: 空グリフのcodepoint不在を検証）/ check緑