### PR TITLE
合成入力ループを4軸バリエーションへ拡張 (#113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ tests/fixtures/mock-scans-distorted/
 tests/fixtures/mock-scans-residue/
 tests/fixtures/mock-scans-metrics/
 tests/fixtures/mock-scans-emptyreview/
+tests/fixtures/mock-scans-jitter/
+tests/fixtures/mock-scans-noise/
+tests/fixtures/mock-scans-lighting/
+tests/fixtures/mock-scans-capture/
 tests/fixtures/test-output.ttf
 tests/fixtures/test-blank-page.png
 tests/fixtures/test-upload*.zip

--- a/tests/e2e/variation-flow.spec.ts
+++ b/tests/e2e/variation-flow.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * 実写ループ拡張 4軸バリエーション e2e（#113）
+ *
+ * 「実写に近いが回復可能」な劣化を乗せた合成テンプレート画像を実ブラウザ
+ * パイプラインに通し、golden path が完走する（or 要確認付きで完走する）ことを
+ * 検証する。各軸は generate-mock-scans.ts の対応ジェネレータが出力する:
+ * - 軸1 手書き風揺らぎ: tests/fixtures/mock-scans-jitter/
+ * - 軸2 ノイズ（ごま塩・微小スペック）: tests/fixtures/mock-scans-noise/
+ * - 軸3 照明（明度勾配 + 影の帯 + コントラスト低下）: tests/fixtures/mock-scans-lighting/
+ * - 軸4 撮影複合（台形 + 回転 + 縮小 + 軽ぼかし）: tests/fixtures/mock-scans-capture/
+ *
+ * 合格バー: [scan:font-input] ok（＝フォント生成入力まで到達）ログが出て
+ * TTF が生成され、そのページの全文字グリフが無傷なこと。段階診断ログ（[scan:*]）が
+ * 収集されているので、落ちた場合はどの段階かを局所化できる。
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { HIRAGANA, CHARS_PER_PAGE } from '../../src/data/characters';
+import {
+  createZipFromFiles,
+  expectGlyphsForChars,
+  loadFont,
+  runScanToFontFlow,
+  withStageLogs,
+} from './font-flow-utils';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+
+// ページ1に描画される文字（HIRAGANA の先頭 CHARS_PER_PAGE 文字）
+const PAGE1_CHARS = HIRAGANA.slice(0, CHARS_PER_PAGE);
+
+/** 各軸の定義: フィクスチャ dir と suffix */
+const AXES = [
+  { name: '軸1 手書き風揺らぎ', dir: 'mock-scans-jitter', suffix: '-jitter.png' },
+  { name: '軸2 ノイズ（ごま塩・スペック）', dir: 'mock-scans-noise', suffix: '-noise.png' },
+  { name: '軸3 照明（明度勾配 + 影の帯）', dir: 'mock-scans-lighting', suffix: '-lighting.png' },
+  {
+    name: '軸4 撮影複合（台形+回転+縮小+ぼかし）',
+    dir: 'mock-scans-capture',
+    suffix: '-capture.png',
+  },
+] as const;
+
+test.describe('実写ループ 4軸バリエーション: 劣化入力でも回復して完走する (#113)', () => {
+  for (const axis of AXES) {
+    test(`${axis.name}: 全ページから83文字全部を抽出してフォント生成まで完走する`, async ({
+      page,
+    }, testInfo) => {
+      test.setTimeout(300_000);
+
+      const axisDir = path.join(FIXTURES_DIR, axis.dir);
+      const files = fs
+        .readdirSync(axisDir)
+        .filter((f) => f.endsWith(axis.suffix))
+        .sort()
+        .map((f) => path.join(axisDir, f));
+      expect(files.length).toBeGreaterThanOrEqual(2);
+
+      const zipPath = path.join(FIXTURES_DIR, `test-upload-${axis.dir}.zip`);
+      await createZipFromFiles(files, zipPath);
+
+      try {
+        const { logs } = await withStageLogs(page, testInfo, async () => {
+          const fontPath = await runScanToFontFlow(page, zipPath);
+          const font = loadFont(fontPath);
+          expectGlyphsForChars(font, HIRAGANA);
+        });
+
+        // 完走の証跡: [scan:font-input] ok（フォント生成入力まで到達）が各ページ分出ている
+        const okLogs = logs.filter((l) => /\[scan:font-input\] ok/.test(l.text));
+        expect(okLogs.length, '[scan:font-input] ok ログが出ていない（未完走）').toBeGreaterThan(0);
+
+        // 段階診断ログが収集されていること（落ちたとき局所化できる前提の担保）
+        expect(
+          logs.some((l) => l.text.startsWith('[scan:')),
+          '段階診断ログが無い',
+        ).toBe(true);
+      } finally {
+        if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);
+      }
+    });
+  }
+
+  test('撮影複合（capture）の1ページからページ1の全文字を抽出できる', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(300_000);
+
+    const captureDir = path.join(FIXTURES_DIR, 'mock-scans-capture');
+    const zipPath = path.join(FIXTURES_DIR, 'test-upload-capture-single.zip');
+    await createZipFromFiles([path.join(captureDir, 'page-01-capture.png')], zipPath);
+
+    try {
+      await withStageLogs(page, testInfo, async () => {
+        const fontPath = await runScanToFontFlow(page, zipPath);
+        const font = loadFont(fontPath);
+        expectGlyphsForChars(font, PAGE1_CHARS);
+      });
+    } finally {
+      if (fs.existsSync(zipPath)) fs.unlinkSync(zipPath);
+    }
+  });
+});

--- a/tests/fixtures/generate-mock-scans.ts
+++ b/tests/fixtures/generate-mock-scans.ts
@@ -70,7 +70,8 @@ import {
 // ひらがな83文字はテンプレート生成と同じ正本（characters.ts）から取得する（二重管理禁止）
 import { HIRAGANA, CHARS_PER_PAGE } from '../../src/data/characters';
 import { getCellPosition } from '../../src/lib/template/layout';
-import { distortPng, DISTORT_VARIANTS } from './distort';
+import { distortPng, DISTORT_VARIANTS, type DistortOptions } from './distort';
+import { mulberry32, addSaltPepperNoise, applyLighting } from './postprocess';
 
 // 解像度: 300dpi 相当（mm→pixel 変換）
 const DPI = 300;
@@ -150,12 +151,70 @@ function drawCellEmptyReviewStroke(ctx: CanvasRenderingContext2D, posX: number, 
   ctx.fillRect(cx, px(posY - 0.5), strokeW, px(CELL_SIZE + 1));
 }
 
+/**
+ * 手書き風の揺らぎをかけてグリフを描く（#113 軸1）。
+ * セル中心を軸に、線太さムラ・微小回転・はみ出し・かすれ・薄描きを乗せる。
+ * seed でセルごとに決定的に振る（フィクスチャ再現性のため）。
+ * 「実写に近いが回復可能」に収めるため強度は中程度に留める:
+ * - 回転 ±2°、拡縮 0.94〜1.02（>1 でセルからわずかにはみ出す）
+ * - 太さムラ 最大 0.03em（同色の重ね描き1回で太らせ、細らせは基準サイズで表現）
+ * - 濃度 0.8〜1.0（薄描き＝かすれ気味）
+ * - かすれスペック 0〜2 個（グリフ bbox 内に紙色の小点を置いて筆画を欠けさせる）
+ */
+function drawGlyphWithJitter(
+  ctx: CanvasRenderingContext2D,
+  char: string,
+  cx: number,
+  cy: number,
+  baseFontPx: number,
+  rand: () => number,
+): void {
+  const rot = ((rand() - 0.5) * 4 * Math.PI) / 180; // ±2°
+  const scale = 0.94 + rand() * 0.08; // 0.94〜1.02（軽いはみ出し）
+  const alpha = 0.8 + rand() * 0.2; // 0.8〜1.0（薄描き＝かすれ気味）
+  const boldPx = rand() * 0.03 * baseFontPx; // 太さムラ（重ね描きオフセット）
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(rot);
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = '#000000';
+  ctx.globalAlpha = alpha;
+  const fontPx = Math.round(baseFontPx * scale);
+  ctx.font = `${fontPx}px "${FIXTURE_FONT_FAMILY}"`;
+  // 太さムラ: 微小オフセットで1回だけ重ね描き（線幅の不均一を近似）。
+  // 過度な重ね描きは隣接する中心マーカーへインクを橋渡しして登録を壊すため控えめに。
+  ctx.fillText(char, 0, 0);
+  if (boldPx >= 1) {
+    ctx.fillText(char, boldPx, 0);
+  }
+  ctx.restore();
+
+  // かすれ: グリフ bbox 内に紙色の微小スペックを置いて筆画を欠けさせる
+  const speckN = Math.floor(rand() * 3); // 0〜2
+  const half = (baseFontPx * scale) / 2;
+  ctx.save();
+  ctx.fillStyle = '#FFFFFF';
+  for (let i = 0; i < speckN; i++) {
+    const sx = cx + (rand() - 0.5) * half * 1.2;
+    const sy = cy + (rand() - 0.5) * half * 1.2;
+    ctx.fillRect(Math.round(sx), Math.round(sy), 2, 2);
+  }
+  ctx.restore();
+
+  ctx.globalAlpha = 1;
+  ctx.textAlign = 'start';
+  ctx.textBaseline = 'alphabetic';
+}
+
 async function generatePage(
   pageIdx: number,
   chars: string[],
   residueCharIndices?: Set<number>,
   qrDataOverride?: string,
   emptyReviewCharIndices?: Set<number>,
+  glyphJitterSeed?: number,
 ): Promise<Buffer> {
   const canvas = createCanvas(canvasW, canvasH);
   const ctx = canvas.getContext('2d');
@@ -302,16 +361,22 @@ async function generatePage(
             // 1.0em で描いて閾値境界から離す（#111 metrics ページで使用）
             const scale = '、。'.includes(char) ? 1.0 : 0.75;
             const fontSize = px(INNER_SIZE * scale);
-            ctx.fillStyle = '#000000';
-            // 同梱サブセットフォントのみ指定（フォールバック列挙しない = 環境差を排除）
-            ctx.font = `${fontSize}px "${FIXTURE_FONT_FAMILY}"`;
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
             const cx = px(pos.x + innerOffset) + px(INNER_SIZE) / 2;
             const cy = px(pos.y + innerOffset) + px(INNER_SIZE) / 2;
-            ctx.fillText(char, cx, cy);
-            ctx.textAlign = 'start';
-            ctx.textBaseline = 'alphabetic';
+            if (glyphJitterSeed !== undefined) {
+              // 手書き風揺らぎ（#113 軸1）。セルごとに決定的な seed で振る
+              const cellRand = mulberry32(glyphJitterSeed * 100003 + charIdx * 131 + pageIdx * 17);
+              drawGlyphWithJitter(ctx, char, cx, cy, fontSize, cellRand);
+            } else {
+              ctx.fillStyle = '#000000';
+              // 同梱サブセットフォントのみ指定（フォールバック列挙しない = 環境差を排除）
+              ctx.font = `${fontSize}px "${FIXTURE_FONT_FAMILY}"`;
+              ctx.textAlign = 'center';
+              ctx.textBaseline = 'middle';
+              ctx.fillText(char, cx, cy);
+              ctx.textAlign = 'start';
+              ctx.textBaseline = 'alphabetic';
+            }
           }
 
           // チェック欄に✓を描画（黒で。シアン除去後も残る）
@@ -519,6 +584,153 @@ export async function generateDistortedScans(
   return files;
 }
 
+// ============================================================================
+// #113 実写ループ拡張: 4軸バリエーション
+// 方針: 実写に近いが「回復可能」な範囲（完走 or 要確認付き完走が基準）。
+// 極端な破壊はしない。複数の中程度フィクスチャで面を張る。
+// ============================================================================
+
+/**
+ * 軸1: 手書き風揺らぎ（#113）。
+ * 全マスのグリフに線太さムラ・微小回転・はみ出し・かすれ・薄描きを乗せた
+ * 正面画像を出力する。強度は drawGlyphWithJitter を参照（回復可能な中程度）。
+ */
+export async function generateJitterScans(outputDir: string): Promise<string[]> {
+  prepareOutputDir(outputDir);
+
+  const totalPages = Math.ceil(HIRAGANA.length / CHARS_PER_PAGE);
+  const files: string[] = [];
+
+  for (let pageIdx = 0; pageIdx < totalPages; pageIdx++) {
+    const start = pageIdx * CHARS_PER_PAGE;
+    const pageChars = HIRAGANA.slice(start, start + CHARS_PER_PAGE);
+
+    const buffer = await generatePage(
+      pageIdx,
+      pageChars,
+      undefined,
+      undefined,
+      undefined,
+      0x113 + pageIdx,
+    );
+    const filename = `page-${String(pageIdx + 1).padStart(2, '0')}-jitter.png`;
+    const filepath = path.join(outputDir, filename);
+    fs.writeFileSync(filepath, buffer);
+    files.push(filepath);
+    console.log(`Generated: ${filename} (handwriting jitter)`);
+  }
+
+  return files;
+}
+
+/**
+ * 軸2: ノイズ（#113）。
+ * 正面画像にごま塩ノイズ + 微小スペックを後処理で乗せる。
+ * 罫線/枠残渣は既存 generateResidueScans が担うので重複させない
+ * （こちらは面的な塩胡椒・ちり/ほこりクラス）。
+ */
+export async function generateNoiseScans(outputDir: string): Promise<string[]> {
+  prepareOutputDir(outputDir);
+
+  const totalPages = Math.ceil(HIRAGANA.length / CHARS_PER_PAGE);
+  const files: string[] = [];
+
+  for (let pageIdx = 0; pageIdx < totalPages; pageIdx++) {
+    const start = pageIdx * CHARS_PER_PAGE;
+    const pageChars = HIRAGANA.slice(start, start + CHARS_PER_PAGE);
+
+    const frontal = await generatePage(pageIdx, pageChars);
+    const buffer = await addSaltPepperNoise(frontal, {
+      saltProb: 0.0015,
+      pepperProb: 0.0015,
+      speckCount: 400,
+      seed: 0x0135 + pageIdx,
+    });
+    const filename = `page-${String(pageIdx + 1).padStart(2, '0')}-noise.png`;
+    const filepath = path.join(outputDir, filename);
+    fs.writeFileSync(filepath, buffer);
+    files.push(filepath);
+    console.log(`Generated: ${filename} (salt-and-pepper noise)`);
+  }
+
+  return files;
+}
+
+/**
+ * 軸3: 照明（#113）。
+ * 正面画像に明度グラデーション + 影の帯 + コントラスト低下を後処理で乗せる。
+ * 二値化がインクと紙を分離できる中程度の強度に留める。ページごとに帯位置を変える。
+ */
+export async function generateLightingScans(outputDir: string): Promise<string[]> {
+  prepareOutputDir(outputDir);
+
+  const totalPages = Math.ceil(HIRAGANA.length / CHARS_PER_PAGE);
+  const files: string[] = [];
+
+  for (let pageIdx = 0; pageIdx < totalPages; pageIdx++) {
+    const start = pageIdx * CHARS_PER_PAGE;
+    const pageChars = HIRAGANA.slice(start, start + CHARS_PER_PAGE);
+
+    const frontal = await generatePage(pageIdx, pageChars);
+    const buffer = await applyLighting(frontal, {
+      gradient: 0.25,
+      contrast: 0.8,
+      shadowBandCenter: 0.35 + pageIdx * 0.2,
+      shadowBandHeight: 0.14,
+      shadowBandStrength: 0.78,
+    });
+    const filename = `page-${String(pageIdx + 1).padStart(2, '0')}-lighting.png`;
+    const filepath = path.join(outputDir, filename);
+    fs.writeFileSync(filepath, buffer);
+    files.push(filepath);
+    console.log(`Generated: ${filename} (lighting gradient + shadow band)`);
+  }
+
+  return files;
+}
+
+/**
+ * 軸4: 撮影複合（#113）。
+ * 台形 + 回転 + 縮小 + 軽ぼかし + 明度ムラを既存の distortPng で複合適用する
+ * （distort.ts の複合アプローチに乗せ、再発明しない）。強度は個々の歪みより
+ * 控えめにして「複合しても回復可能」に収める。
+ */
+const CAPTURE_COMPOSITE_OPTS: DistortOptions = {
+  rotateDeg: 2,
+  trapezoid: 0.03,
+  // 縮小 + 軽ぼかしの複合。0.9 まで縮めると QR モジュール解像度が落ちて
+  // ぼかしと重なった時に読めなくなる。既存 combined(scale 0.92)+blur が通ることを
+  // 踏まえ、QR モジュール解像度に余裕を持たせて 0.93 に設定する。
+  scale: 0.93,
+  padding: 200,
+  brightnessGradient: 0.12,
+  blur: true,
+};
+
+export async function generateCaptureScans(outputDir: string): Promise<string[]> {
+  prepareOutputDir(outputDir);
+
+  const totalPages = Math.ceil(HIRAGANA.length / CHARS_PER_PAGE);
+  const files: string[] = [];
+
+  for (let pageIdx = 0; pageIdx < totalPages; pageIdx++) {
+    const start = pageIdx * CHARS_PER_PAGE;
+    const pageChars = HIRAGANA.slice(start, start + CHARS_PER_PAGE);
+
+    const frontal = await generatePage(pageIdx, pageChars);
+    // ページごとに回転方向を反転させて片寄りを避ける
+    const opts = { ...CAPTURE_COMPOSITE_OPTS, rotateDeg: pageIdx % 2 === 0 ? 2 : -2 };
+    const buffer = await distortPng(frontal, opts);
+    const filename = `page-${String(pageIdx + 1).padStart(2, '0')}-capture.png`;
+    const filepath = path.join(outputDir, filename);
+    fs.writeFileSync(filepath, buffer);
+    files.push(filepath);
+    console.log(`Generated: ${filename} (capture composite)`);
+  }
+
+  return files;
+}
+
 // CLI から直接実行された場合
 if (
   process.argv[1]?.endsWith('generate-mock-scans.ts') ||
@@ -530,11 +742,19 @@ if (
   const residueDir = path.join(fixturesDir, 'mock-scans-residue');
   const emptyReviewDir = path.join(fixturesDir, 'mock-scans-emptyreview');
   const metricsDir = path.join(fixturesDir, 'mock-scans-metrics');
+  const jitterDir = path.join(fixturesDir, 'mock-scans-jitter');
+  const noiseDir = path.join(fixturesDir, 'mock-scans-noise');
+  const lightingDir = path.join(fixturesDir, 'mock-scans-lighting');
+  const captureDir = path.join(fixturesDir, 'mock-scans-capture');
   generateMockScans(outDir)
     .then((files) => generateDistortedScans(files, distortedDir).then((d) => [...files, ...d]))
     .then((files) => generateResidueScans(residueDir).then((r) => [...files, ...r]))
     .then((files) => generateEmptyReviewScans(emptyReviewDir).then((r) => [...files, ...r]))
     .then((files) => generateMetricsScans(metricsDir).then((m) => [...files, ...m]))
+    .then((files) => generateJitterScans(jitterDir).then((j) => [...files, ...j]))
+    .then((files) => generateNoiseScans(noiseDir).then((n) => [...files, ...n]))
+    .then((files) => generateLightingScans(lightingDir).then((l) => [...files, ...l]))
+    .then((files) => generateCaptureScans(captureDir).then((c) => [...files, ...c]))
     .then((files) => {
       console.log(`\nDone! Generated ${files.length} mock scan images.`);
     })

--- a/tests/fixtures/postprocess.ts
+++ b/tests/fixtures/postprocess.ts
@@ -1,0 +1,151 @@
+/**
+ * 合成スキャン画像の後処理（#113 実写ループ拡張）
+ *
+ * 正面レンダリング済みの PNG バッファに対し、実写に近いが回復可能な範囲の
+ * 劣化を後処理として乗せる:
+ * - ごま塩ノイズ（salt-and-pepper）+ 微小スペック
+ * - 照明ムラ（明度グラデーション + 影の帯 + コントラスト低下）
+ *
+ * 罫線残渣・枠残渣は既存の drawCellResidue（generateResidueScans）が担うため
+ * ここでは扱わない（重複回避）。台形/回転/縮小/ぼかしは distort.ts が担う。
+ *
+ * パラメータは「実写に近いが回復可能」に寄せる: 二値化・マーカー/QR 検出が
+ * 破綻しない密度・強度に留め、複数の中程度フィクスチャで面を張る。
+ */
+
+import { createCanvas, loadImage } from 'canvas';
+
+/** 決定的乱数（mulberry32）。フィクスチャ再現性のため seed 固定で使う。 */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface NoiseOptions {
+  /** 各ピクセルが塩（白点）になる確率 */
+  saltProb?: number;
+  /** 各ピクセルが胡椒（黒点）になる確率 */
+  pepperProb?: number;
+  /** 追加で撒く微小スペック（1〜2px 塊）の個数 */
+  speckCount?: number;
+  /** 乱数シード */
+  seed?: number;
+}
+
+/**
+ * ごま塩ノイズ + 微小スペックを乗せる。
+ * 密度は低め（既定 0.15% 前後）に留め、四隅マーカー（大きい塗り円）や
+ * QR（誤り訂正 M）を壊さない範囲にする。
+ */
+export async function addSaltPepperNoise(input: Buffer, opts: NoiseOptions = {}): Promise<Buffer> {
+  const saltProb = opts.saltProb ?? 0.0015;
+  const pepperProb = opts.pepperProb ?? 0.0015;
+  const speckCount = opts.speckCount ?? 400;
+  const rand = mulberry32(opts.seed ?? 0x5a17);
+
+  const img = await loadImage(input);
+  const w = img.width;
+  const h = img.height;
+  const canvas = createCanvas(w, h);
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  const imageData = ctx.getImageData(0, 0, w, h);
+  const d = imageData.data;
+
+  for (let i = 0; i < w * h; i++) {
+    const r = rand();
+    if (r < pepperProb) {
+      const o = i * 4;
+      d[o] = d[o + 1] = d[o + 2] = 0;
+    } else if (r < pepperProb + saltProb) {
+      const o = i * 4;
+      d[o] = d[o + 1] = d[o + 2] = 255;
+    }
+  }
+
+  // 微小スペック: 1〜2px の黒/白の塊（ちり・ほこり）
+  for (let s = 0; s < speckCount; s++) {
+    const cx = Math.floor(rand() * w);
+    const cy = Math.floor(rand() * h);
+    const size = rand() < 0.75 ? 1 : 2;
+    const black = rand() < 0.6;
+    const v = black ? 0 : 255;
+    for (let dy = 0; dy < size; dy++) {
+      for (let dx = 0; dx < size; dx++) {
+        const x = cx + dx;
+        const y = cy + dy;
+        if (x >= w || y >= h) continue;
+        const o = (y * w + x) * 4;
+        d[o] = d[o + 1] = d[o + 2] = v;
+      }
+    }
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  return canvas.toBuffer('image/png');
+}
+
+export interface LightingOptions {
+  /** 上下方向の明度グラデーション幅（例 0.25 → 上 +12.5% 〜 下 −12.5%） */
+  gradient?: number;
+  /** 影の帯の中心 y（0〜1 の相対位置）。未指定なら帯なし */
+  shadowBandCenter?: number;
+  /** 影の帯の相対高さ（0〜1） */
+  shadowBandHeight?: number;
+  /** 影の帯の暗さ（乗算係数, 例 0.75） */
+  shadowBandStrength?: number;
+  /** コントラスト低下係数（1=変化なし, 0.7=中央グレーへ 30% 寄せる） */
+  contrast?: number;
+}
+
+/**
+ * 照明ムラを乗せる: 明度グラデーション + 影の帯 + コントラスト低下。
+ * 二値化がインク（黒）と紙（白）を分離できる強度に留める
+ * （黒→コントラスト0.7でも ~38 で十分暗い）。
+ */
+export async function applyLighting(input: Buffer, opts: LightingOptions = {}): Promise<Buffer> {
+  const gradient = opts.gradient ?? 0.25;
+  const contrast = opts.contrast ?? 0.8;
+  const bandCenter = opts.shadowBandCenter;
+  const bandHeight = opts.shadowBandHeight ?? 0.12;
+  const bandStrength = opts.shadowBandStrength ?? 0.78;
+
+  const img = await loadImage(input);
+  const w = img.width;
+  const h = img.height;
+  const canvas = createCanvas(w, h);
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  const imageData = ctx.getImageData(0, 0, w, h);
+  const d = imageData.data;
+
+  const bandY0 = bandCenter === undefined ? -1 : (bandCenter - bandHeight / 2) * h;
+  const bandY1 = bandCenter === undefined ? -1 : (bandCenter + bandHeight / 2) * h;
+
+  for (let y = 0; y < h; y++) {
+    // 明度グラデーション: 上端 1+g/2 → 下端 1-g/2
+    let mult = 1 + gradient * (0.5 - y / (h - 1));
+    // 影の帯（乗算）
+    if (bandCenter !== undefined && y >= bandY0 && y <= bandY1) {
+      mult *= bandStrength;
+    }
+    for (let x = 0; x < w; x++) {
+      const o = (y * w + x) * 4;
+      for (let c = 0; c < 3; c++) {
+        let v = d[o + c] * mult;
+        // コントラスト低下: 中央グレー(128)へ寄せる
+        v = 128 + (v - 128) * contrast;
+        d[o + c] = v < 0 ? 0 : v > 255 ? 255 : Math.round(v);
+      }
+    }
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  return canvas.toBuffer('image/png');
+}


### PR DESCRIPTION
## 概要
#109 の合成 golden path の上に、実写に近い4軸バリエーションを自動生成→スキャン→段階特定できる状態に拡張。全軸が「完走 or 要確認付き完走」することを実ブラウザ e2e で検証する。

Closes #113

## 4軸（issue §やること）
1. **手書き揺らぎ**: 回転±2°/拡縮0.94-1.02/かすれalpha0.8-1.0/微小スペック（seed付きmulberry32で決定論的）
2. **ノイズ**: ごま塩0.3%+微小スペック400/頁（罫線残渣は既存Residueと非重複）
3. **照明**: 明度グラデ25%+影の帯×0.78+コントラスト0.8
4. **撮影複合**: 台形+回転±2°+縮小0.93+3x3ぼかし

## 検証
- `variation-flow.spec.ts`(5件): 各軸を実パイプラインに通し**全83字の非空グリフ登録**+`[scan:font-input] ok`+段階診断ログを検証。#117のスキップ由来欠字（codepoint不在）も`missing`として捕捉する強い判定
- test:generate-fixtures 21画像 / e2e 15全緑 / vitest 98 / check緑
- フィクスチャ決定論的（seed固定・Math.random/Date.now不使用）・生成dirは.gitignore

## 副産物（実写帰還に有用）
較正で判明したパイプラインの**回復可能上限**: jitter拡大≤1.02・capture縮小≥0.93（QRモジュール解像度が下限）。製品コードは無改変（初期失敗2件はフィクスチャが回復可能範囲を超過していたための較正）。

## 関連
- #103 緑化fixtureが回帰網に積まれる / #110 ノイズ軸がゲート検証を兼ねる / 次は #115（マーカー欠落誤診断）→実写1ページ帰還